### PR TITLE
Add flag to hide TOC header

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,13 +206,14 @@ func main() {
 		"If not entered, then read Markdown from stdin."
 	paths := kingpin.Arg("path", pathsDesc).Strings()
 	serial := kingpin.Flag("serial", "Grab TOCs in the serial mode").Bool()
+	hideHeader := kingpin.Flag("hide-header", "Hide TOC header").Bool()
 	depth := kingpin.Flag("depth", "How many levels of headings to include. Defaults to 0 (all)").Default("0").Int()
 	kingpin.Version(version)
 	kingpin.Parse()
 
 	pathsCount := len(*paths)
 
-	if pathsCount == 1 {
+	if !*hideHeader && pathsCount == 1 {
 		fmt.Println()
 		fmt.Println("Table of Contents")
 		fmt.Println("=================")


### PR DESCRIPTION
This update should address https://github.com/ekalinin/github-markdown-toc.go/issues/9.

I wanted to leave the default behavior to include a TOC header, but the
way https://github.com/alecthomas/kingpin#boolean-values work make it
difficult, so I head to create a negated flag.

I wanted to create a `header` flag, but I was not able to setup a
default value for a boolean flag. I was not able to discern a missing
flag from a negative value.

I thought of calling the flag `no-header`, but kingpin defines a
`--no-*` flag by default, so it would have ended up including a
`--no-no-header`, so I chose `--hide-header` instead.