### PR TITLE
Add support for custom start depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ See the releases page, "Downloads" section:
 For example:
 
 ```bash
-$ wget https://github.com/ekalinin/github-markdown-toc.go/releases/download/0.4.0/gh-md-toc.linux.amd64.tgz
+$ wget https://github.com/ekalinin/github-markdown-toc.go/releases/download/1.1.0/gh-md-toc.linux.amd64.tgz
 $ tar xzvf gh-md-toc.linux.amd64.tgz
 gh-md-toc
 $ ./gh-md-toc --version
-0.4.0
+1.1.0
 ```
 
 Compiling from source
@@ -69,13 +69,20 @@ $ ./gh-md-toc --help
 usage: gh-md-toc [<flags>] [<path>...]
 
 Flags:
-  --help     Show help (also see --help-long and --help-man).
-  --version  Show application version.
-  --depth    How many levels of headings to include. Defaults to 0 (all)
+  --help           Show context-sensitive help (also try --help-long and --help-man).
+  --serial         Grab TOCs in the serial mode
+  --hide-header    Hide TOC header
+  --hide-footer    Hide TOC footer
+  --start-depth=0  Start including from this level. Defaults to 0 (include all levels)
+  --depth=0        How many levels of headings to include. Defaults to 0 (all)
+  --no-escape      Do not escape chars in sections
+  --token=TOKEN    GitHub personal token
+  --indent=2       Indent space of generated list
+  --debug          Show debug info
+  --version        Show application version.
 
 Args:
-  [<path>]  Local path or URL of the document to grab TOC
-
+  [<path>]  Local path or URL of the document to grab TOC. Read MD from stdin if not entered.
 ```
 
 Homebew (Mac only)
@@ -266,6 +273,24 @@ You can easily combine both ways:
     * [Installation](https://github.com/ekalinin/sitemap.js/blob/master/README.md#installation)
     * [Usage](https://github.com/ekalinin/sitemap.js/blob/master/README.md#usage)
     * [License](https://github.com/ekalinin/sitemap.js/blob/master/README.md#license)
+
+Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
+```
+
+Starting Depth
+--------------
+
+Use `--start-depth=INT` to control the starting header level (i.e. include only the levels
+starting with `INT`)
+
+```bash
+➥ ./gh-md-toc --start-depth=1 ~/projects/Dockerfile.vim/README.md
+
+Table of Contents
+=================
+
+  * [Or using Pathogen:](#or-using-pathogen)
+  * [Or using Vundle:](#or-using-vundle)
 
 Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 ```

--- a/ghdoc.go
+++ b/ghdoc.go
@@ -24,19 +24,20 @@ func (toc *GHToc) Print() {
 
 // GHDoc GitHub document
 type GHDoc struct {
-	Path     string
-	AbsPaths bool
-	Depth    int
-	Escape   bool
-	GhToken  string
-	Indent   int
-	Debug    bool
-	html     string
+	Path       string
+	AbsPaths   bool
+	StartDepth int
+	Depth      int
+	Escape     bool
+	GhToken    string
+	Indent     int
+	Debug      bool
+	html       string
 }
 
 // NewGHDoc create GHDoc
-func NewGHDoc(Path string, AbsPaths bool, Depth int, Escape bool, Token string, Indent int, Debug bool) *GHDoc {
-	return &GHDoc{Path, AbsPaths, Depth, Escape, Token, Indent, Debug, ""}
+func NewGHDoc(Path string, AbsPaths bool, StartDepth int, Depth int, Escape bool, Token string, Indent int, Debug bool) *GHDoc {
+	return &GHDoc{Path, AbsPaths, StartDepth, Depth, Escape, Token, Indent, Debug, ""}
 }
 
 func (doc *GHDoc) d(msg string) {
@@ -141,9 +142,13 @@ func (doc *GHDoc) GrabToc() *GHToc {
 
 	var tmpSection string
 	doc.d("GrabToc: processing groups ...")
+	doc.d("Including starting frome level " + strconv.Itoa(doc.StartDepth))
 	for _, group := range groups {
 		// format result
 		n, _ := strconv.Atoi(group["num"])
+		if n <= doc.StartDepth {
+			continue
+		}
 		if doc.Depth > 0 && n > doc.Depth {
 			continue
 		}
@@ -157,7 +162,7 @@ func (doc *GHDoc) GrabToc() *GHToc {
 		if doc.Escape {
 			tmpSection = EscapeSpecChars(tmpSection)
 		}
-		tocItem := strings.Repeat(listIndentation(), n-minHeaderNum) + "* " +
+		tocItem := strings.Repeat(listIndentation(), n-minHeaderNum-doc.StartDepth) + "* " +
 			"[" + tmpSection + "]" +
 			"(" + link + ")"
 		//fmt.Println(tocItem)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var (
 	serial     = kingpin.Flag("serial", "Grab TOCs in the serial mode").Bool()
 	hideHeader = kingpin.Flag("hide-header", "Hide TOC header").Bool()
 	hideFooter = kingpin.Flag("hide-footer", "Hide TOC footer").Bool()
+	startDepth = kingpin.Flag("start-depth", "Start including from this level. Defaults to 0 (include all levels)").Default("0").Int()
 	depth      = kingpin.Flag("depth", "How many levels of headings to include. Defaults to 0 (all)").Default("0").Int()
 	noEscape   = kingpin.Flag("no-escape", "Do not escape chars in sections").Bool()
 	token      = kingpin.Flag("token", "GitHub personal token").String()
@@ -42,7 +43,7 @@ func main() {
 	ch := make(chan *GHToc, pathsCount)
 
 	for _, p := range *paths {
-		ghdoc := NewGHDoc(p, absPathsInToc, *depth, !*noEscape, *token, *indent, *debug)
+		ghdoc := NewGHDoc(p, absPathsInToc, *startDepth, *depth, !*noEscape, *token, *indent, *debug)
 		if *serial {
 			ch <- ghdoc.GetToc()
 		} else {
@@ -75,7 +76,7 @@ func main() {
 		defer os.Remove(file.Name())
 
 		check(ioutil.WriteFile(file.Name(), bytes, 0644))
-		NewGHDoc(file.Name(), false, *depth, !*noEscape, *token, *indent, *debug).GetToc().Print()
+		NewGHDoc(file.Name(), false, *startDepth, *depth, !*noEscape, *token, *indent, *debug).GetToc().Print()
 	}
 
 	if !*hideFooter {

--- a/main_test.go
+++ b/main_test.go
@@ -183,6 +183,61 @@ func Test_GrabTocDepth(t *testing.T) {
 	}
 }
 
+func Test_GrabTocStartDepth(t *testing.T) {
+	tocExpected := []string{
+		"* [The command foo2 is better](#the-command-foo2-is-better)",
+		"  * [The command foo3 is even betterer](#the-command-foo3-is-even-betterer)",
+		"* [The command bar2 is better](#the-command-bar2-is-better)",
+		"  * [The command bar3 is even betterer](#the-command-bar3-is-even-betterer)",
+	}
+
+	doc := &GHDoc{
+		html: `
+<h1>
+<a id="user-content-the-command-foo1" class="anchor" href="#the-command-foo1" aria-hidden="true"><span class="octicon octicon-link"></span></a>The command <code>foo1</code>
+</h1>
+
+<p>Blabla...</p>
+
+<h2>
+<a id="user-content-the-command-foo2-is-better" class="anchor" href="#the-command-foo2-is-better" aria-hidden="true"><span class="octicon octicon-link"></span></a>The command <code>foo2</code> is better</h2>
+
+<p>Blabla...</p>
+
+<h3>
+<a id="user-content-the-command-foo3-is-even-betterer" class="anchor" href="#the-command-foo3-is-even-betterer" aria-hidden="true"><span class="octicon octicon-link"></span></a>The command <code>foo3</code> is even betterer</h2>
+
+<p>Blabla...</p>
+
+<h1>
+<a id="user-content-the-command-bar1" class="anchor" href="#the-command-bar1" aria-hidden="true"><span class="octicon octicon-link"></span></a>The command <code>bar1</code>
+</h1>
+
+<p>Blabla...</p>
+
+<h2>
+<a id="user-content-the-command-bar2-is-better" class="anchor" href="#the-command-bar2-is-better" aria-hidden="true"><span class="octicon octicon-link"></span></a>The command <code>bar2</code> is better</h2>
+
+<p>Blabla...</p>
+
+<h3>
+<a id="user-content-the-command-bar3-is-even-betterer" class="anchor" href="#the-command-bar3-is-even-betterer" aria-hidden="true"><span class="octicon octicon-link"></span></a>The command <code>bar3</code> is even betterer</h2>
+
+<p>Blabla...</p>
+	`, AbsPaths: false,
+		Escape: true,
+		StartDepth:  1,
+		Indent: 2,
+	}
+	toc := *doc.GrabToc()
+
+	for i := 0; i <= len(tocExpected)-1; i++ {
+		if toc[i] != tocExpected[i] {
+			t.Error("Res :", toc[i], "\nExpected      :", tocExpected[i])
+		}
+	}
+}
+
 func Test_GrabTocWithAbspath(t *testing.T) {
 	link := "https://github.com/ekalinin/envirius/blob/master/README.md"
 	tocExpected := []string{


### PR DESCRIPTION
This adds a `--start-depth` command line option, that allows specifying a
custom start depth (i.e. if you would like to skip the first header (H1)) with
the default value of 0.

Fixes ekalinin/github-markdown-toc.go#24
