### PR TITLE
feat: add github-url option

### DIFF
--- a/cmd/gh-md-toc/main.go
+++ b/cmd/gh-md-toc/main.go
@@ -22,6 +22,7 @@ var (
 	token      = kingpin.Flag("token", "GitHub personal token").String()
 	indent     = kingpin.Flag("indent", "Indent space of generated list").Default("2").Int()
 	debug      = kingpin.Flag("debug", "Show debug info").Bool()
+	ghurl      = kingpin.Flag("github-url", "GitHub URL, default=https://api.github.com").String()
 )
 
 // check if there was an error (and panic if it was)
@@ -40,6 +41,10 @@ func main() {
 		*token = os.Getenv("GH_TOC_TOKEN")
 	}
 
+	if *ghurl == "" {
+		*ghurl = os.Getenv("GH_TOC_URL")
+	}
+
 	pathsCount := len(*paths)
 
 	// read file paths | urls from args
@@ -48,6 +53,8 @@ func main() {
 
 	for _, p := range *paths {
 		ghdoc := ghtoc.NewGHDoc(p, absPathsInToc, *startDepth, *depth, !*noEscape, *token, *indent, *debug)
+		ghdoc.SetGHURL(*ghurl)
+
 		if *serial {
 			ch <- ghdoc.GetToc()
 		} else {
@@ -81,6 +88,7 @@ func main() {
 
 		check(os.WriteFile(file.Name(), bytes, 0644))
 		check(ghtoc.NewGHDoc(file.Name(), false, *startDepth, *depth, !*noEscape, *token, *indent, *debug).
+			SetGHURL(*ghurl).
 			GetToc().
 			Print(os.Stdout))
 	}

--- a/ghdoc.go
+++ b/ghdoc.go
@@ -40,10 +40,13 @@ type GHDoc struct {
 	GhToken    string
 	Indent     int
 	Debug      bool
+
+	// internals
 	html       string
 	logger     *log.Logger
 	httpGetter httpGetter
 	httpPoster httpPoster
+	ghURL      string
 }
 
 // NewGHDoc create GHDoc
@@ -61,6 +64,7 @@ func NewGHDoc(Path string, AbsPaths bool, StartDepth int, Depth int, Escape bool
 		logger:     log.New(os.Stderr, "", log.LstdFlags),
 		httpGetter: httpGet,
 		httpPoster: httpPost,
+		ghURL:      "https://api.github.com",
 	}
 }
 
@@ -68,6 +72,14 @@ func (doc *GHDoc) d(msg string) {
 	if doc.Debug {
 		doc.logger.Println(msg)
 	}
+}
+
+// SetGHURL sets new GitHub URL (protocol + host)
+func (doc *GHDoc) SetGHURL(url string) *GHDoc {
+	if url != "" {
+		doc.ghURL = url
+	}
+	return doc
 }
 
 // IsRemoteFile checks if path is for remote file or not
@@ -82,7 +94,7 @@ func (doc *GHDoc) IsRemoteFile() bool {
 }
 
 func (doc *GHDoc) convertMd2Html(localPath string, token string) (string, error) {
-	ghURL := "https://api.github.com/markdown/raw"
+	ghURL := doc.ghURL + "/markdown/raw"
 	return doc.httpPoster(ghURL, localPath, token)
 }
 

--- a/ghdoc_test.go
+++ b/ghdoc_test.go
@@ -546,3 +546,32 @@ func TestGrabToc_issue35(t *testing.T) {
 		}
 	}
 }
+
+func TestSetGHURL(t *testing.T) {
+	noSense := "xxx"
+	doc := NewGHDoc(noSense, true, 0, 0, true, noSense, 4, true)
+
+	ghURL := "https://api.github.com"
+	if doc.ghURL != ghURL {
+		t.Error("Res :", doc.ghURL, "\nExpected     :", ghURL)
+	}
+
+	ghURL = "https://api.xxx.com"
+	doc.SetGHURL(ghURL)
+	if doc.ghURL != ghURL {
+		t.Error("Res :", doc.ghURL, "\nExpected     :", ghURL)
+	}
+
+	// mock for converting md to txt (just to check passing new GH URL)
+	doc.httpPoster = func(urlPath, filePath, token string) (string, error) {
+		ghURLFull := ghURL + "/markdown/raw"
+		if urlPath != ghURLFull {
+			t.Error("Res :", urlPath, "\nExpected     :", ghURL)
+		}
+		return noSense, nil
+	}
+
+	if _, err := doc.convertMd2Html(noSense, noSense); err != nil {
+		t.Error("Convert error:", err)
+	}
+}


### PR DESCRIPTION
Besides CLI, environment variable is supported too (`GH_TOC_URL`).

Fixes #43 