### PR TITLE
fix: regex expression bug

### DIFF
--- a/ghdoc.go
+++ b/ghdoc.go
@@ -155,7 +155,8 @@ func (doc *GHDoc) GrabToc() *GHToc {
 
 	re := `(?si)<h(?P<num>[1-6])>\s*` +
 		`<a\s*id="user-content-[^"]*"\s*class="anchor"\s*` +
-		`(aria-hidden="[^"]*"\s*)?` +
+		`(aria-hidden="[^"]*")?\s*` +
+		`(tabindex="[^"]*")?\s*` +
 		`href="(?P<href>[^"]*)"[^>]*>\s*` +
 		`.*?</a>(?P<name>.*?)</h`
 	r := regexp.MustCompile(re)


### PR DESCRIPTION
<img width="926" alt="image" src="https://github.com/ekalinin/github-markdown-toc.go/assets/46625434/6761d079-1b93-428a-b39d-a8a5a13884d1">

Due to an update in the https://api.github.com/markdown/raw, there have been changes in the returned content, resulting in a bug in regular expression parsing.