### PR TITLE
fix: module paths for v2

### DIFF
--- a/cmd/gh-md-toc/main.go
+++ b/cmd/gh-md-toc/main.go
@@ -6,8 +6,8 @@ import (
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/app"
-	"github.com/ekalinin/github-markdown-toc.go/internal/version"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/app"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ekalinin/github-markdown-toc.go
+module github.com/ekalinin/github-markdown-toc.go/v2
 
 go 1.19
 

--- a/internal/adapters/filechecker.go
+++ b/internal/adapters/filechecker.go
@@ -3,7 +3,7 @@ package adapters
 import (
 	"os"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 )
 
 type FileChecker struct {

--- a/internal/adapters/filewriter.go
+++ b/internal/adapters/filewriter.go
@@ -3,7 +3,7 @@ package adapters
 import (
 	"os"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 )
 
 type FileWriter struct {

--- a/internal/adapters/htmlconverter.go
+++ b/internal/adapters/htmlconverter.go
@@ -1,7 +1,7 @@
 package adapters
 
 import (
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 )
 
 type HTMLConverter struct {

--- a/internal/adapters/logger.go
+++ b/internal/adapters/logger.go
@@ -3,7 +3,7 @@ package adapters
 import (
 	"log/slog"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 )
 
 type Logger struct {

--- a/internal/adapters/remoteposter.go
+++ b/internal/adapters/remoteposter.go
@@ -1,8 +1,8 @@
 package adapters
 
 import (
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
-	"github.com/ekalinin/github-markdown-toc.go/internal/utils"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
 )
 
 type realPoster struct {

--- a/internal/adapters/remotergetter.go
+++ b/internal/adapters/remotergetter.go
@@ -1,6 +1,6 @@
 package adapters
 
-import "github.com/ekalinin/github-markdown-toc.go/internal/utils"
+import "github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
 
 type RemoteGetter struct {
 	asJSON bool

--- a/internal/adapters/tocgrabber_json.go
+++ b/internal/adapters/tocgrabber_json.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/entity"
-	"github.com/ekalinin/github-markdown-toc.go/internal/utils"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
 )
 
 type JsonGrabber struct {

--- a/internal/adapters/tocgrabber_re.go
+++ b/internal/adapters/tocgrabber_re.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/entity"
-	"github.com/ekalinin/github-markdown-toc.go/internal/utils"
-	"github.com/ekalinin/github-markdown-toc.go/internal/version"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
 
 type ReGrabber struct {

--- a/internal/adapters/tocgrabber_re_test.go
+++ b/internal/adapters/tocgrabber_re_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/version"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
 
 const (

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -1,8 +1,8 @@
 package app
 
 import (
-	"github.com/ekalinin/github-markdown-toc.go/internal/adapters"
-	"github.com/ekalinin/github-markdown-toc.go/internal/controller"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/adapters"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/controller"
 )
 
 // copy of controller.Config

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -3,9 +3,9 @@ package app
 import (
 	"io"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/adapters"
-	"github.com/ekalinin/github-markdown-toc.go/internal/controller"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/adapters"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/controller"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase"
 )
 
 type Controller interface {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -3,7 +3,7 @@ package app
 import (
 	"io"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/utils"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
 )
 
 func (a *App) Run(stdout io.Writer) error {

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase/config"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
 )
 
 type Config struct {

--- a/internal/controller/file.go
+++ b/internal/controller/file.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 )
 
 func (ctl *Controller) getUseCase(file string) useCase {

--- a/internal/controller/new.go
+++ b/internal/controller/new.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/entity"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 )
 
 type useCase interface {

--- a/internal/core/ports/ports.go
+++ b/internal/core/ports/ports.go
@@ -3,7 +3,7 @@ package ports
 import (
 	"os"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 )
 
 type FileChecker interface {

--- a/internal/core/usecase/localmd/localmd.go
+++ b/internal/core/usecase/localmd/localmd.go
@@ -1,9 +1,9 @@
 package localmd
 
 import (
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/entity"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase/config"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
 )
 
 // - read file

--- a/internal/core/usecase/new.go
+++ b/internal/core/usecase/new.go
@@ -1,11 +1,11 @@
 package usecase
 
 import (
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase/config"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase/localmd"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase/remotehtml"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase/remotemd"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/localmd"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/remotehtml"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/remotemd"
 )
 
 func New(cfg config.Config,

--- a/internal/core/usecase/remotehtml/remotehtml.go
+++ b/internal/core/usecase/remotehtml/remotehtml.go
@@ -1,9 +1,9 @@
 package remotehtml
 
 import (
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/entity"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase/config"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
 )
 
 // - download json file

--- a/internal/core/usecase/remotemd/remotemd.go
+++ b/internal/core/usecase/remotemd/remotemd.go
@@ -3,10 +3,10 @@ package remotemd
 import (
 	"strings"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/entity"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/ports"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase/config"
-	"github.com/ekalinin/github-markdown-toc.go/internal/core/usecase/localmd"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/localmd"
 )
 
 // - download remote file

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/version"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
 
 // doHTTPReq executes a particular http request

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ekalinin/github-markdown-toc.go/internal/version"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
 
 func TestHttpGet(t *testing.T) {


### PR DESCRIPTION
Module paths updated to v2 to follow semantic versioning.
This PR closes https://github.com/ekalinin/github-markdown-toc.go/issues/54.

```
# make test
0 issues.
        github.com/ekalinin/github-markdown-toc.go/v2/cmd/gh-md-toc             coverage: 0.0% of statements
ok      github.com/ekalinin/github-markdown-toc.go/v2/internal/adapters 0.007s  coverage: 99.0% of statements
ok      github.com/ekalinin/github-markdown-toc.go/v2/internal/app      0.003s  coverage: 33.3% of statements
        github.com/ekalinin/github-markdown-toc.go/v2/internal/controller               coverage: 0.0% of statements
ok      github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity      0.002s  coverage: 100.0% of statements
?       github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports       [no test files]
        github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase             coverage: 0.0% of statements
?       github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config      [no test files]
        github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/localmd             coverage: 0.0% of statements
        github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/remotehtml          coverage: 0.0% of statements
        github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/remotemd            coverage: 0.0% of statements
ok      github.com/ekalinin/github-markdown-toc.go/v2/internal/utils    0.006s  coverage: 87.7% of statements
?       github.com/ekalinin/github-markdown-toc.go/v2/internal/version  [no test files]
```