### PR TITLE
chore(ci): align Go toolchain and checks

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: "1.26.5"
 
       - name: Run converting
         run: make e2e

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,7 +54,9 @@ jobs:
         run: go mod tidy -diff
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
 
       - name: Test with race detector and coverage
         run: go test -race -v -coverprofile=coverage.out -covermode=atomic ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,23 +4,38 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.yml"
-      - "**/*.yaml"
-      - "Makefile"
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.yml"
-      - "**/*.yaml"
-      - "Makefile"
 
 jobs:
-  build:
-    name: Build, Test, Coverage
+  test:
+    name: Test with Go ${{ matrix.go-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1.21.x"
+          - "1.26.5"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...
+
+  quality:
+    name: Quality
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,18 +45,33 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: "1.26.5"
+
+      - name: Verify modules
+        run: go mod verify
+
+      - name: Check module files
+        run: go mod tidy -diff
 
       - name: Lint
         uses: golangci/golangci-lint-action@v6
 
-      - name: Build
-        run: go build -v ./...
-
-      - name: Test & Coverage
-        run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Test with race detector and coverage
+        run: go test -race -v -coverprofile=coverage.out -covermode=atomic ./...
+        env:
+          CGO_ENABLED: "1"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.2.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  vulnerability:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: "1.26.5"
+          go-package: ./...

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: "1.26.5"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ ./gh-md-toc --version
 Compiling from source
 ---------------------
 
-You need golang installed in your OS:
+You need Go 1.21 or newer installed in your OS:
 
 ```bash
 $ make build
@@ -100,7 +100,7 @@ Args:
 Go Install
 ------------------
 
-You need golang installed in your OS:
+You need Go 1.21 or newer installed in your OS:
 
 ```bash
 go install "github.com/ekalinin/github-markdown-toc.go/cmd/gh-md-toc@latest"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ekalinin/github-markdown-toc.go/v2
 
-go 1.19
+go 1.21
 
 require gopkg.in/alecthomas/kingpin.v2 v2.2.4
 


### PR DESCRIPTION
## Summary

- raise the minimum supported Go version to 1.21
- test Go 1.21.x and Go 1.26.5 in CI
- add module integrity, race, coverage, and vulnerability checks
- build e2e and release workflows with Go 1.26.5
- run CI for workflow, Markdown, and Makefile changes
- document the minimum Go version

## Validation

- go test ./... with Go 1.21.13
- go test -race ./... with Go 1.26.5
- go vet ./...
- golangci-lint run ./...
- go mod tidy -diff
- go mod verify
- govulncheck ./...
- actionlint v1.7.12