### PR TITLE
fix(config): protect secrets and validate inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Flags:
   --token=TOKEN    GitHub personal token
   --indent=2       Indent space of generated list
   --debug          Show debug info
+  --github-url="https://api.github.com"
+                   GitHub URL. Default: https://api.github.com
+  --re-version=2024-03
+                   RegExp version. Default: 2024-03
   --version        Show application version.
 
 Args:

--- a/cmd/gh-md-toc/config.go
+++ b/cmd/gh-md-toc/config.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/app"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
+)
+
+const (
+	cliName          = "gh-md-toc"
+	defaultGitHubURL = "https://api.github.com"
+)
+
+type cliOptions struct {
+	paths      *[]string
+	serial     *bool
+	hideHeader *bool
+	hideFooter *bool
+	startDepth *int
+	depth      *int
+	noEscape   *bool
+	token      *string
+	indent     *int
+	debug      *bool
+	githubURL  *string
+	reVersion  *string
+}
+
+func newCLI() (*kingpin.Application, cliOptions) {
+	parser := kingpin.New(cliName, "")
+	parser.Version(version.Version)
+
+	pathsDesc := "Local path or URL of the document to grab TOC. Read MD from stdin if not entered."
+	options := cliOptions{
+		paths:      parser.Arg("path", pathsDesc).Strings(),
+		serial:     parser.Flag("serial", "Grab TOCs in the serial mode").Bool(),
+		hideHeader: parser.Flag("hide-header", "Hide TOC header").Bool(),
+		hideFooter: parser.Flag("hide-footer", "Hide TOC footer").Bool(),
+		startDepth: parser.Flag("start-depth", "Start including from this level. Defaults to 0 (include all levels)").Default("0").Int(),
+		depth:      parser.Flag("depth", "How many levels of headings to include. Defaults to 0 (all)").Default("0").Int(),
+		noEscape:   parser.Flag("no-escape", "Do not escape chars in sections").Bool(),
+		token:      parser.Flag("token", "GitHub personal token").Envar("GH_TOC_TOKEN").String(),
+		indent:     parser.Flag("indent", "Indent space of generated list").Default("2").Int(),
+		debug:      parser.Flag("debug", "Show debug info").Bool(),
+		githubURL: parser.Flag(
+			"github-url",
+			"GitHub URL. Default: "+defaultGitHubURL,
+		).Default(defaultGitHubURL).Envar("GH_TOC_URL").String(),
+		reVersion: parser.Flag(
+			"re-version",
+			"RegExp version. Default: "+version.GH_2024_03,
+		).Default(version.GH_2024_03).Enum(version.SupportedGHVersions()...),
+	}
+
+	return parser, options
+}
+
+func parseConfig(args []string) (app.Config, error) {
+	parser, options := newCLI()
+	if _, err := parser.Parse(args); err != nil {
+		return app.Config{}, err
+	}
+
+	return app.Config{
+		Files:      *options.paths,
+		Serial:     *options.serial,
+		HideHeader: *options.hideHeader,
+		HideFooter: *options.hideFooter,
+		StartDepth: *options.startDepth,
+		Depth:      *options.depth,
+		NoEscape:   *options.noEscape,
+		Indent:     *options.indent,
+		Debug:      *options.debug,
+		GHToken:    *options.token,
+		GHUrl:      *options.githubURL,
+		GHVersion:  *options.reVersion,
+	}, nil
+}

--- a/cmd/gh-md-toc/config_test.go
+++ b/cmd/gh-md-toc/config_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
+)
+
+func TestParseConfigDefaults(t *testing.T) {
+	t.Setenv("GH_TOC_TOKEN", "")
+	t.Setenv("GH_TOC_URL", "")
+
+	cfg, err := parseConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.Files) != 0 {
+		t.Errorf("got files %v, want none", cfg.Files)
+	}
+	if cfg.GHToken != "" {
+		t.Errorf("got token %q, want empty", cfg.GHToken)
+	}
+	if cfg.GHUrl != defaultGitHubURL {
+		t.Errorf("got GitHub URL %q, want %q", cfg.GHUrl, defaultGitHubURL)
+	}
+	if cfg.GHVersion != version.GH_2024_03 {
+		t.Errorf("got regexp version %q, want %q", cfg.GHVersion, version.GH_2024_03)
+	}
+}
+
+func TestParseConfigReadsEnvironment(t *testing.T) {
+	t.Setenv("GH_TOC_TOKEN", "environment-token")
+	t.Setenv("GH_TOC_URL", "https://github.example/api/v3")
+
+	cfg, err := parseConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.GHToken != "environment-token" {
+		t.Errorf("got token %q, want environment token", cfg.GHToken)
+	}
+	if cfg.GHUrl != "https://github.example/api/v3" {
+		t.Errorf("got GitHub URL %q, want environment URL", cfg.GHUrl)
+	}
+}
+
+func TestParseConfigFlagsOverrideEnvironment(t *testing.T) {
+	t.Setenv("GH_TOC_TOKEN", "environment-token")
+	t.Setenv("GH_TOC_URL", "https://environment.example/api/v3")
+
+	args := []string{
+		"--token=flag-token",
+		"--github-url=https://flag.example/api/v3",
+		"--re-version=" + version.GH_V0,
+		"--serial",
+		"one.md",
+		"two.md",
+	}
+	cfg, err := parseConfig(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.GHToken != "flag-token" {
+		t.Errorf("got token %q, want flag token", cfg.GHToken)
+	}
+	if cfg.GHUrl != "https://flag.example/api/v3" {
+		t.Errorf("got GitHub URL %q, want flag URL", cfg.GHUrl)
+	}
+	if cfg.GHVersion != version.GH_V0 {
+		t.Errorf("got regexp version %q, want %q", cfg.GHVersion, version.GH_V0)
+	}
+	if !cfg.Serial {
+		t.Error("serial mode is disabled")
+	}
+	if want := []string{"one.md", "two.md"}; !slices.Equal(cfg.Files, want) {
+		t.Errorf("got files %v, want %v", cfg.Files, want)
+	}
+}
+
+func TestParseConfigEmptyFlagsOverrideEnvironment(t *testing.T) {
+	t.Setenv("GH_TOC_TOKEN", "environment-token")
+	t.Setenv("GH_TOC_URL", "https://environment.example/api/v3")
+
+	cfg, err := parseConfig([]string{"--token=", "--github-url="})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.GHToken != "" {
+		t.Errorf("got token %q, want empty flag value", cfg.GHToken)
+	}
+	if cfg.GHUrl != "" {
+		t.Errorf("got GitHub URL %q, want empty flag value", cfg.GHUrl)
+	}
+}
+
+func TestParseConfigAcceptsSupportedRegexpVersions(t *testing.T) {
+	t.Setenv("GH_TOC_TOKEN", "")
+	t.Setenv("GH_TOC_URL", "")
+
+	for _, supported := range version.SupportedGHVersions() {
+		t.Run(supported, func(t *testing.T) {
+			cfg, err := parseConfig([]string{"--re-version=" + supported})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.GHVersion != supported {
+				t.Errorf("got regexp version %q, want %q", cfg.GHVersion, supported)
+			}
+		})
+	}
+}
+
+func TestParseConfigRejectsUnknownRegexpVersion(t *testing.T) {
+	_, err := parseConfig([]string{"--re-version=unknown"})
+	if err == nil {
+		t.Fatal("expected an error for an unsupported regexp version")
+	}
+
+	for _, expected := range []string{"unknown", "0", "2023-10", "2024-03"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("error %q does not contain %q", err, expected)
+		}
+	}
+}
+
+func TestCLIHelpShowsCurrentDefaultsWithoutToken(t *testing.T) {
+	t.Setenv("GH_TOC_TOKEN", "secret-token")
+	t.Setenv("GH_TOC_URL", "https://github.example/api/v3")
+
+	parser, _ := newCLI()
+	var output bytes.Buffer
+	parser.UsageWriter(&output)
+	parser.Usage(nil)
+
+	help := output.String()
+	for _, expected := range []string{
+		"GitHub URL. Default: " + defaultGitHubURL,
+		"RegExp version. Default: " + version.GH_2024_03,
+	} {
+		if !strings.Contains(help, expected) {
+			t.Errorf("help does not contain %q:\n%s", expected, help)
+		}
+	}
+	if strings.Contains(help, "secret-token") {
+		t.Errorf("help contains GitHub token:\n%s", help)
+	}
+}

--- a/cmd/gh-md-toc/main.go
+++ b/cmd/gh-md-toc/main.go
@@ -4,57 +4,22 @@ import (
 	"log"
 	"os"
 
-	"gopkg.in/alecthomas/kingpin.v2"
-
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/app"
-	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
-)
-
-var (
-	pathsDesc  = "Local path or URL of the document to grab TOC. Read MD from stdin if not entered."
-	paths      = kingpin.Arg("path", pathsDesc).Strings()
-	serial     = kingpin.Flag("serial", "Grab TOCs in the serial mode").Bool()
-	hideHeader = kingpin.Flag("hide-header", "Hide TOC header").Bool()
-	hideFooter = kingpin.Flag("hide-footer", "Hide TOC footer").Bool()
-	startDepth = kingpin.Flag("start-depth", "Start including from this level. Defaults to 0 (include all levels)").Default("0").Int()
-	depth      = kingpin.Flag("depth", "How many levels of headings to include. Defaults to 0 (all)").Default("0").Int()
-	noEscape   = kingpin.Flag("no-escape", "Do not escape chars in sections").Bool()
-	token      = kingpin.Flag("token", "GitHub personal token").String()
-	indent     = kingpin.Flag("indent", "Indent space of generated list").Default("2").Int()
-	debug      = kingpin.Flag("debug", "Show debug info").Bool()
-	ghurl      = kingpin.Flag("github-url", "GitHub URL, default=https://api.github.com").Default("https://api.github.com").String()
-	reVersion  = kingpin.Flag("re-version", "RegExp version, default=0").Default(version.GH_2024_03).String()
 )
 
 // Entry point
 func main() {
-	kingpin.Version(version.Version)
-	kingpin.Parse()
-
-	if *token == "" {
-		*token = os.Getenv("GH_TOC_TOKEN")
+	cfg, err := parseConfig(os.Args[1:])
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	if *ghurl == "" {
-		*ghurl = os.Getenv("GH_TOC_URL")
+	application, err := app.New(cfg)
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	cfg := app.Config{
-		Files:      *paths,
-		Serial:     *serial,
-		HideHeader: *hideHeader,
-		HideFooter: *hideFooter,
-		StartDepth: *startDepth,
-		Depth:      *depth,
-		NoEscape:   *noEscape,
-		Indent:     *indent,
-		Debug:      *debug,
-		GHToken:    *token,
-		GHUrl:      *ghurl,
-		GHVersion:  *reVersion,
-	}
-
-	if err := app.New(cfg).Run(os.Stdout); err != nil {
+	if err := application.Run(os.Stdout); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/adapters/tocgrabber_re.go
+++ b/internal/adapters/tocgrabber_re.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"fmt"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -17,37 +18,47 @@ type ReGrabber struct {
 	re *regexp.Regexp
 }
 
-func NewReGrabber(path string, cfg GrabberCfg, reVersion string) *ReGrabber {
+func NewReGrabber(path string, cfg GrabberCfg, reVersion string) (*ReGrabber, error) {
 	// si:
 	// 	- s - let . match \n (single-line mode)
 	//  - i - case-insensitive
-	re := ""
-	if reVersion == version.GH_V0 {
-		re = `(?si)<h(?P<num>[1-6])>\s*` +
+	var pattern string
+	switch reVersion {
+	case version.GH_V0:
+		pattern = `(?si)<h(?P<num>[1-6])>\s*` +
 			`<a\s*id="user-content-[^"]*"\s*class="anchor"\s*` +
 			`(aria-hidden="[^"]*"\s*)?` +
 			`(tabindex="[^"]*"\s*)?` +
 			`href="(?P<href>[^"]*)"[^>]*>\s*` +
 			`.*?</a>(?P<name>.*?)</h`
-	}
-	if reVersion == version.GH_2023_10 {
-		re = `(?si)<h(?P<num>[1-6]) id="[^"]+">\s*` +
+	case version.GH_2023_10:
+		pattern = `(?si)<h(?P<num>[1-6]) id="[^"]+">\s*` +
 			`<a class="heading-link"\s*` +
 			`href="(?P<href>[^"]+)">\s*` +
 			`(?P<name>.*?)<span`
-	}
-	if reVersion == version.GH_2024_03 {
-		re = `(?si)<h(?P<num>[1-6]) class="heading-element">(?P<name>.*?)</h\d>` +
+	case version.GH_2024_03:
+		pattern = `(?si)<h(?P<num>[1-6]) class="heading-element">(?P<name>.*?)</h\d>` +
 			`<a\s*id="user-content-[^"]*"\s*` +
 			`class="[^"]*"\s*` +
 			`aria-label="[^"]*"\s*` +
 			`href="(?P<href>[^"]+)">`
+	default:
+		return nil, fmt.Errorf(
+			"unsupported GitHub regexp version %q; supported versions: %s",
+			reVersion,
+			strings.Join(version.SupportedGHVersions(), ", "),
+		)
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("compile GitHub regexp version %q: %w", reVersion, err)
 	}
 
 	return &ReGrabber{
 		cfg: cfg,
-		re:  regexp.MustCompile(re),
-	}
+		re:  re,
+	}, nil
 }
 
 func (g *ReGrabber) Grab(html string) (*entity.Toc, error) {

--- a/internal/adapters/tocgrabber_re_test.go
+++ b/internal/adapters/tocgrabber_re_test.go
@@ -27,8 +27,14 @@ type reTest struct {
 func checkTest(t *testing.T, tests []reTest, cfg GrabberCfg, expected []string) {
 	for _, d := range tests {
 		t.Run(fmt.Sprintf("v.%s", d.version), func(t *testing.T) {
-			grabber := NewReGrabber("", cfg, d.version)
-			toc, _ := grabber.Grab(d.html)
+			grabber, err := NewReGrabber("", cfg, d.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+			toc, err := grabber.Grab(d.html)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if len(*toc) != len(expected) {
 				t.Errorf("Rows differs. Got: %d, want: %d (got toc=%v)\n",
 					len(*toc), len(expected), *toc)
@@ -40,6 +46,18 @@ func checkTest(t *testing.T, tests []reTest, cfg GrabberCfg, expected []string) 
 				}
 			}
 		})
+	}
+}
+
+func Test_NewReGrabberRejectsUnknownVersion(t *testing.T) {
+	_, err := NewReGrabber("", DefaultCfg(), "unknown")
+	if err == nil {
+		t.Fatal("expected an error for an unsupported regexp version")
+	}
+
+	want := "unsupported GitHub regexp version \"unknown\"; supported versions: 0, 2023-10, 2024-03"
+	if err.Error() != want {
+		t.Errorf("got error %q, want %q", err, want)
 	}
 }
 

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/adapters"
@@ -17,10 +18,22 @@ type App struct {
 	ctl Controller
 }
 
-func New(cfg Config) *App {
+func New(cfg Config) (*App, error) {
 	log := adapters.NewLogger(cfg.Debug)
 
-	log.Info("App.New: init configs ...", "app cfg", cfg)
+	log.Info(
+		"App.New: init configs ...",
+		"file-count", len(cfg.Files),
+		"serial", cfg.Serial,
+		"hide-header", cfg.HideHeader,
+		"hide-footer", cfg.HideFooter,
+		"start-depth", cfg.StartDepth,
+		"depth", cfg.Depth,
+		"no-escape", cfg.NoEscape,
+		"indent", cfg.Indent,
+		"github-version", cfg.GHVersion,
+		"token-configured", cfg.GHToken != "",
+	)
 	ctlCfg := cfg.ToControllerConfig()
 	ucCfg := ctlCfg.ToUseCaseConfig()
 
@@ -28,7 +41,10 @@ func New(cfg Config) *App {
 	checker := adapters.NewFileCheck(log)
 	writer := adapters.NewFileWriter(log)
 	converter := adapters.NewHTMLConverter(cfg.GHToken, cfg.GHUrl, log)
-	grabberRe := adapters.NewReGrabber("", cfg.ToGrabberConfig(), cfg.GHVersion)
+	grabberRe, err := adapters.NewReGrabber("", cfg.ToGrabberConfig(), cfg.GHVersion)
+	if err != nil {
+		return nil, fmt.Errorf("initialize regexp grabber: %w", err)
+	}
 	grabberJson := adapters.NewJsonGrabber(cfg.ToGrabberConfig())
 	getter := adapters.NewRemoteGetter(true)
 	temper := adapters.NewFileTemper()
@@ -46,5 +62,5 @@ func New(cfg Config) *App {
 	return &App{
 		ctl: ctl,
 		cfg: cfg,
-	}
+	}, nil
 }

--- a/internal/app/new_test.go
+++ b/internal/app/new_test.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
+)
+
+func TestNewDoesNotLogGitHubToken(t *testing.T) {
+	var output bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	const token = "secret-token"
+	_, err := New(Config{
+		Debug:     true,
+		GHToken:   token,
+		GHUrl:     "https://api.github.com",
+		GHVersion: version.GH_2024_03,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logOutput := output.String()
+	if strings.Contains(logOutput, token) {
+		t.Errorf("debug log contains GitHub token: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "token-configured=true") {
+		t.Errorf("debug log does not report token presence safely: %s", logOutput)
+	}
+}
+
+func TestNewRejectsUnknownRegexpVersion(t *testing.T) {
+	_, err := New(Config{GHVersion: "unknown"})
+	if err == nil {
+		t.Fatal("expected an error for an unsupported regexp version")
+	}
+
+	want := "initialize regexp grabber: unsupported GitHub regexp version \"unknown\""
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("got error %q, want it to contain %q", err, want)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -12,3 +12,12 @@ const (
 	GH_2023_10 = "2023-10"
 	GH_2024_03 = "2024-03"
 )
+
+// SupportedGHVersions returns the supported GitHub layout versions.
+func SupportedGHVersions() []string {
+	return []string{
+		GH_V0,
+		GH_2023_10,
+		GH_2024_03,
+	}
+}


### PR DESCRIPTION
## Reason

PR #59 was merged into the `chore/go-toolchain-baseline` branch after PR #58 had already been merged into `master`. Therefore, the changes from PR #59 are absent from `master`.

This PR applies the same commit to a branch created from the current `master`.

## Checks

- `go test ./...`
- `go test -race ./...`
- `golangci-lint run`