### PR TITLE
refactor(core): propagate context and errors

### DIFF
--- a/cmd/gh-md-toc/main.go
+++ b/cmd/gh-md-toc/main.go
@@ -1,25 +1,44 @@
 package main
 
 import (
-	"log"
+	"context"
+	"fmt"
+	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/app"
 )
 
 // Entry point
 func main() {
-	cfg, err := parseConfig(os.Args[1:])
+	os.Exit(runWithSignals(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func runWithSignals(args []string, stdout, stderr io.Writer) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return run(ctx, args, stdout, stderr)
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	cfg, err := parseConfig(args)
 	if err != nil {
-		log.Fatal(err)
+		_, _ = fmt.Fprintln(stderr, err)
+		return 1
 	}
 
 	application, err := app.New(cfg)
 	if err != nil {
-		log.Fatal(err)
+		_, _ = fmt.Fprintln(stderr, err)
+		return 1
 	}
 
-	if err := application.Run(os.Stdout); err != nil {
-		log.Fatal(err)
+	if err := application.Run(ctx, stdout); err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return 1
 	}
+	return 0
 }

--- a/cmd/gh-md-toc/main_test.go
+++ b/cmd/gh-md-toc/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunReturnsNonZeroForMissingFile(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing.md")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run(
+		context.Background(),
+		[]string{"--hide-header", missingPath},
+		&stdout,
+		&stderr,
+	)
+
+	if code == 0 {
+		t.Fatal("got exit code 0, want a non-zero exit code")
+	}
+	if !strings.Contains(stderr.String(), missingPath) {
+		t.Errorf("error output %q does not contain the document path", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Created by") {
+		t.Errorf("footer was printed after an error: %q", stdout.String())
+	}
+}

--- a/internal/adapters/filechecker.go
+++ b/internal/adapters/filechecker.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"os"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
@@ -14,10 +15,22 @@ func NewFileCheck(log ports.Logger) *FileChecker {
 	return &FileChecker{log: log}
 }
 
-func (ch *FileChecker) Exists(file string) bool {
+func (ch *FileChecker) Exists(ctx context.Context, file string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
 	ch.log.Info("FileChecker.Exists: start", "file", file)
 	_, err := os.Stat(file)
-	res := !os.IsNotExist(err)
+	if err == nil {
+		ch.log.Info("FileChecker.Exists: done", "res", true)
+		return true, nil
+	}
+	if !os.IsNotExist(err) {
+		return false, err
+	}
+
+	res := false
 	ch.log.Info("FileChecker.Exists: done", "res", res)
-	return res
+	return res, nil
 }

--- a/internal/adapters/filechecker_test.go
+++ b/internal/adapters/filechecker_test.go
@@ -1,6 +1,9 @@
 package adapters
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func Test_FileChecker(t *testing.T) {
 	tests := []struct {
@@ -16,7 +19,11 @@ func Test_FileChecker(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			if got := checker.Exists(tt.path); got != tt.want {
+			got, err := checker.Exists(context.Background(), tt.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
 				t.Errorf("Got=%v, want=%v", got, tt.want)
 			}
 		})

--- a/internal/adapters/filetemper.go
+++ b/internal/adapters/filetemper.go
@@ -1,6 +1,9 @@
 package adapters
 
-import "os"
+import (
+	"context"
+	"os"
+)
 
 type FileTemper struct {
 }
@@ -9,6 +12,9 @@ func NewFileTemper() *FileTemper {
 	return &FileTemper{}
 }
 
-func (f *FileTemper) CreateTemp(dir, pattern string) (*os.File, error) {
+func (f *FileTemper) CreateTemp(ctx context.Context, dir, pattern string) (*os.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return os.CreateTemp(dir, pattern)
 }

--- a/internal/adapters/filetemper_test.go
+++ b/internal/adapters/filetemper_test.go
@@ -1,6 +1,9 @@
 package adapters
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func Test_FileTemper(t *testing.T) {
 	tests := []struct {
@@ -12,11 +15,16 @@ func Test_FileTemper(t *testing.T) {
 	checker := NewFileCheck(NewLogger(false))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f, err := temper.CreateTemp("", "gh-toc-tests-*")
+			ctx := context.Background()
+			f, err := temper.CreateTemp(ctx, "", "gh-toc-tests-*")
 			if err != nil {
 				t.Errorf("Got err=%v", err)
 			}
-			if !checker.Exists(f.Name()) {
+			exists, err := checker.Exists(ctx, f.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !exists {
 				t.Errorf("File not exists, f=%v", f.Name())
 			}
 		})

--- a/internal/adapters/filewriter.go
+++ b/internal/adapters/filewriter.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"os"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
@@ -14,6 +15,9 @@ func NewFileWriter(log ports.Logger) *FileWriter {
 	return &FileWriter{log: log}
 }
 
-func (f *FileWriter) Write(file string, data []byte) error {
+func (f *FileWriter) Write(ctx context.Context, file string, data []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return os.WriteFile(file, data, 0644)
 }

--- a/internal/adapters/filewriter_test.go
+++ b/internal/adapters/filewriter_test.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"os"
 	"testing"
 )
@@ -17,11 +18,16 @@ func Test_FileWriter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			file := "./tmp-for-test"
 			test_data := "some-test"
-			err := writer.Write(file, []byte(test_data))
+			ctx := context.Background()
+			err := writer.Write(ctx, file, []byte(test_data))
 			if err != nil {
 				t.Errorf("Got err=%v", err)
 			}
-			if !checker.Exists(file) {
+			exists, err := checker.Exists(ctx, file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !exists {
 				t.Errorf("File not exists, f=%v", file)
 			}
 			data, err := os.ReadFile(file)

--- a/internal/adapters/htmlconverter.go
+++ b/internal/adapters/htmlconverter.go
@@ -1,6 +1,8 @@
 package adapters
 
 import (
+	"context"
+
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 )
 
@@ -24,9 +26,9 @@ func NewHTMLConverterX(token, url string, poster ports.RemotePoster, log ports.L
 	}
 }
 
-func (c *HTMLConverter) Convert(file string) (string, error) {
+func (c *HTMLConverter) Convert(ctx context.Context, file string) (string, error) {
 	c.log.Info("adapters.HTMLConverter.Convert: start", "file", file)
 	ghURL := c.ghURL + "/markdown/raw"
 	c.log.Info("adapters.HTMLConverter.Convert: sending", "url", ghURL)
-	return c.poster.Post(ghURL, c.ghToken, file)
+	return c.poster.Post(ctx, ghURL, c.ghToken, file)
 }

--- a/internal/adapters/htmlconverter_test.go
+++ b/internal/adapters/htmlconverter_test.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -13,7 +14,7 @@ type fakePoster struct {
 	retErr   error
 }
 
-func (p *fakePoster) Post(url, token, path string) (string, error) {
+func (p *fakePoster) Post(_ context.Context, url, token, path string) (string, error) {
 	p.gotPath = path
 	p.gotToken = token
 	p.gotURL = url
@@ -38,7 +39,7 @@ func Test_HTMLConverter(t *testing.T) {
 			converter := NewHTMLConverterX(token, url,
 				tt.poster, NewLogger(false))
 
-			got, err := converter.Convert(path)
+			got, err := converter.Convert(context.Background(), path)
 			if tt.failed {
 				if err == nil {
 					t.Errorf("Should be failed, but no errors.")

--- a/internal/adapters/remoteposter.go
+++ b/internal/adapters/remoteposter.go
@@ -1,6 +1,8 @@
 package adapters
 
 import (
+	"context"
+
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
 )
@@ -8,7 +10,10 @@ import (
 type realPoster struct {
 }
 
-func (p *realPoster) Post(url, token, path string) (string, error) {
+func (p *realPoster) Post(ctx context.Context, url, token, path string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	return utils.HttpPost(url, path, token)
 }
 
@@ -24,6 +29,6 @@ func NewRemotePosterX(poster ports.RemotePoster) *RemotePoster {
 	return &RemotePoster{poster: poster}
 }
 
-func (r *RemotePoster) Post(url, token, path string) (string, error) {
-	return r.poster.Post(url, token, path)
+func (r *RemotePoster) Post(ctx context.Context, url, token, path string) (string, error) {
+	return r.poster.Post(ctx, url, token, path)
 }

--- a/internal/adapters/remoteposter.go
+++ b/internal/adapters/remoteposter.go
@@ -14,7 +14,7 @@ func (p *realPoster) Post(ctx context.Context, url, token, path string) (string,
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
-	return utils.HttpPost(url, path, token)
+	return utils.HttpPost(ctx, url, path, token)
 }
 
 type RemotePoster struct {

--- a/internal/adapters/remoteposter_test.go
+++ b/internal/adapters/remoteposter_test.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,8 +20,9 @@ func Test_RemotePoster(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
 			if tt.fake {
-				got, err := tt.remotePoster.Post("url", "token", "path")
+				got, err := tt.remotePoster.Post(ctx, "url", "token", "path")
 				if err != nil {
 					t.Errorf("got err=%v", err)
 				}
@@ -29,7 +31,7 @@ func Test_RemotePoster(t *testing.T) {
 				}
 			} else {
 				testToken := "token-for-test"
-				fileName, err := NewFileTemper().CreateTemp("", "example.*.txt")
+				fileName, err := NewFileTemper().CreateTemp(ctx, "", "example.*.txt")
 				if err != nil {
 					t.Error("Tmp file creation err=", err)
 				}
@@ -57,7 +59,7 @@ func Test_RemotePoster(t *testing.T) {
 				}))
 				defer srv.Close()
 
-				if _, err := tt.remotePoster.Post(srv.URL, testToken, fileName.Name()); err != nil {
+				if _, err := tt.remotePoster.Post(ctx, srv.URL, testToken, fileName.Name()); err != nil {
 					t.Error("Should not be err, but got=", err)
 				}
 			}

--- a/internal/adapters/remotergetter.go
+++ b/internal/adapters/remotergetter.go
@@ -1,6 +1,10 @@
 package adapters
 
-import "github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
+import (
+	"context"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
+)
 
 type RemoteGetter struct {
 	asJSON bool
@@ -10,7 +14,10 @@ func NewRemoteGetter(asJSON bool) *RemoteGetter {
 	return &RemoteGetter{asJSON: asJSON}
 }
 
-func (r *RemoteGetter) Get(path string) ([]byte, string, error) {
+func (r *RemoteGetter) Get(ctx context.Context, path string) ([]byte, string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
 	if r.asJSON {
 		return utils.HttpGetJson(path)
 	}

--- a/internal/adapters/remotergetter.go
+++ b/internal/adapters/remotergetter.go
@@ -19,7 +19,7 @@ func (r *RemoteGetter) Get(ctx context.Context, path string) ([]byte, string, er
 		return nil, "", err
 	}
 	if r.asJSON {
-		return utils.HttpGetJson(path)
+		return utils.HttpGetJson(ctx, path)
 	}
-	return utils.HttpGet(path)
+	return utils.HttpGet(ctx, path)
 }

--- a/internal/adapters/remotergetter_test.go
+++ b/internal/adapters/remotergetter_test.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -34,7 +35,7 @@ func Test_RemoteGetterPlain(t *testing.T) {
 	defer srv.Close()
 
 	getter := NewRemoteGetter(false)
-	body, _, err := getter.Get(srv.URL)
+	body, _, err := getter.Get(context.Background(), srv.URL)
 	got := string(body)
 
 	if err != nil {
@@ -51,7 +52,7 @@ func Test_RemoteGetterJson(t *testing.T) {
 	defer srv.Close()
 
 	getter := NewRemoteGetter(true)
-	body, _, err := getter.Get(srv.URL)
+	body, _, err := getter.Get(context.Background(), srv.URL)
 	got := string(body)
 
 	if err != nil {

--- a/internal/adapters/tocgrabber_json.go
+++ b/internal/adapters/tocgrabber_json.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -47,7 +48,11 @@ func (w tocWrapper) tocSource() []tocItem {
 	return w.Payload.CodeViewBlobRoute.HeaderInfo.Toc
 }
 
-func (g JsonGrabber) Grab(jsonBody string) (*entity.Toc, error) {
+func (g JsonGrabber) Grab(ctx context.Context, jsonBody string) (*entity.Toc, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	var wrapper tocWrapper
 	err := json.Unmarshal([]byte(jsonBody), &wrapper)
 	if err != nil {
@@ -62,11 +67,17 @@ func (g JsonGrabber) Grab(jsonBody string) (*entity.Toc, error) {
 	listIndentation := utils.GenerateListIndentation(g.cfg.Indent)
 	minHeaderNum := 6
 	for _, item := range items {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if item.Level < minHeaderNum {
 			minHeaderNum = item.Level
 		}
 	}
 	for _, item := range items {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if item.Level <= g.cfg.StartDepth {
 			continue
 		}

--- a/internal/adapters/tocgrabber_json_test.go
+++ b/internal/adapters/tocgrabber_json_test.go
@@ -1,6 +1,9 @@
 package adapters
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func getTestJson() string {
 	// how to get example:
@@ -106,7 +109,7 @@ func getTestJsonCodeViewRoute() string {
 
 func Test_JsonGrabberDefault(t *testing.T) {
 	grabber := NewJsonGrabber(DefaultCfg())
-	toc, err := grabber.Grab(getTestJson())
+	toc, err := grabber.Grab(context.Background(), getTestJson())
 	if err != nil {
 		t.Errorf("got error from grabber: %v", err)
 	}
@@ -134,7 +137,7 @@ func Test_JsonGrabberDefault(t *testing.T) {
 
 func Test_JsonGrabberCodeViewBlobRoute(t *testing.T) {
 	grabber := NewJsonGrabber(DefaultCfg())
-	toc, err := grabber.Grab(getTestJsonCodeViewRoute())
+	toc, err := grabber.Grab(context.Background(), getTestJsonCodeViewRoute())
 	if err != nil {
 		t.Errorf("got error from grabber: %v", err)
 	}
@@ -150,7 +153,7 @@ func Test_JSONGrabberWithOptions(t *testing.T) {
 	cfg.AbsPaths = true
 	cfg.Path = "github-markdown-toc.go"
 	grabber := NewJsonGrabber(cfg)
-	toc, err := grabber.Grab(getTestJson())
+	toc, err := grabber.Grab(context.Background(), getTestJson())
 	if err != nil {
 		t.Errorf("got error from grabber: %v", err)
 	}
@@ -175,7 +178,7 @@ func Test_JSONGrabberWithOptions(t *testing.T) {
 func Test_JSONGrabberFail(t *testing.T) {
 	jsonBody := `{`
 	grabber := NewJsonGrabber(DefaultCfg())
-	_, err := grabber.Grab(jsonBody)
+	_, err := grabber.Grab(context.Background(), jsonBody)
 	if err == nil {
 		t.Errorf("should fail")
 	}

--- a/internal/adapters/tocgrabber_re.go
+++ b/internal/adapters/tocgrabber_re.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -61,7 +62,10 @@ func NewReGrabber(path string, cfg GrabberCfg, reVersion string) (*ReGrabber, er
 	}, nil
 }
 
-func (g *ReGrabber) Grab(html string) (*entity.Toc, error) {
+func (g *ReGrabber) Grab(ctx context.Context, html string) (*entity.Toc, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	listIndentation := utils.GenerateListIndentation(g.cfg.Indent)
 
@@ -70,6 +74,9 @@ func (g *ReGrabber) Grab(html string) (*entity.Toc, error) {
 	var groups []map[string]string
 	// doc.d("GrabToc: matching ...")
 	for _, match := range g.re.FindAllStringSubmatch(html, -1) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		// doc.d("GrabToc: match #" + strconv.Itoa(idx) + " ...")
 		group := make(map[string]string)
 		// fill map for groups
@@ -92,6 +99,9 @@ func (g *ReGrabber) Grab(html string) (*entity.Toc, error) {
 	// doc.d("GrabToc: processing groups ...")
 	// doc.d("Including starting from level " + strconv.Itoa(doc.StartDepth))
 	for _, group := range groups {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		// format result
 		n, _ := strconv.Atoi(group["num"])
 		if n <= g.cfg.StartDepth {

--- a/internal/adapters/tocgrabber_re_test.go
+++ b/internal/adapters/tocgrabber_re_test.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -31,7 +32,7 @@ func checkTest(t *testing.T, tests []reTest, cfg GrabberCfg, expected []string) 
 			if err != nil {
 				t.Fatal(err)
 			}
-			toc, err := grabber.Grab(d.html)
+			toc, err := grabber.Grab(context.Background(), d.html)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -10,7 +11,7 @@ import (
 )
 
 type Controller interface {
-	Process(stdout io.Writer) error
+	Process(ctx context.Context, stdout io.Writer) error
 }
 
 type App struct {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -1,19 +1,20 @@
 package app
 
 import (
+	"context"
 	"io"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
 )
 
-func (a *App) Run(stdout io.Writer) error {
+func (a *App) Run(ctx context.Context, stdout io.Writer) error {
 
 	// do not show for stdin case (Files is empty)
 	if !a.cfg.HideHeader && len(a.cfg.Files) == 1 {
 		utils.ShowHeader(stdout)
 	}
 
-	if err := a.ctl.Process(stdout); err != nil {
+	if err := a.ctl.Process(ctx, stdout); err != nil {
 		return err
 	}
 

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 )
 
@@ -13,17 +15,14 @@ type TestController struct {
 	body string
 }
 
-func (c TestController) Process(stdout io.Writer) error {
-	if c.err != nil {
-		return c.err
-	}
+func (c TestController) Process(_ context.Context, stdout io.Writer) error {
 	if len(c.body) > 0 {
 		if _, err := fmt.Fprint(stdout, c.body); err != nil {
 			return err
 		}
 
 	}
-	return nil
+	return c.err
 }
 
 func Test_AppRun(t *testing.T) {
@@ -38,7 +37,7 @@ func Test_AppRun(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	if err := app.Run(&b); err != nil {
+	if err := app.Run(context.Background(), &b); err != nil {
 		t.Error(err)
 	}
 
@@ -50,16 +49,22 @@ func Test_AppRun(t *testing.T) {
 }
 
 func Test_AppRunFail(t *testing.T) {
-	errWant := errors.New("Proccess failed!")
-	ctl := TestController{err: errWant}
+	errWant := errors.New("process failed")
+	ctl := TestController{err: errWant, body: "partial result\n"}
 	app := App{
 		cfg: Config{},
 		ctl: ctl,
 	}
 
 	var b bytes.Buffer
-	err := app.Run(&b)
-	if err.Error() != errWant.Error() {
-		t.Errorf("\nWant=%s\n Got=%s", errWant.Error(), err.Error())
+	err := app.Run(context.Background(), &b)
+	if !errors.Is(err, errWant) {
+		t.Errorf("\nWant=%s\n Got=%v", errWant, err)
+	}
+	if strings.Contains(b.String(), "Created by") {
+		t.Errorf("footer was printed after an error: %q", b.String())
+	}
+	if !strings.Contains(b.String(), "partial result") {
+		t.Errorf("successful partial output was lost: %q", b.String())
 	}
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,0 +1,107 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+)
+
+type useCaseFunc func(context.Context, string) (entity.Toc, error)
+
+func (f useCaseFunc) Do(ctx context.Context, path string) (entity.Toc, error) {
+	return f(ctx, path)
+}
+
+type loggerStub struct{}
+
+func (loggerStub) Info(string, ...any) {}
+
+func newTestController(cfg Config, uc useCase) *Controller {
+	return New(cfg, uc, uc, uc, loggerStub{})
+}
+
+func TestProcessFilesPrintsSuccessfulResultsAndAggregatesErrors(t *testing.T) {
+	firstErr := errors.New("first failure")
+	secondErr := errors.New("second failure")
+	uc := useCaseFunc(func(_ context.Context, path string) (entity.Toc, error) {
+		switch path {
+		case "good.md":
+			return entity.Toc{"* [Good](#good)"}, nil
+		case "first.md":
+			return nil, firstErr
+		default:
+			return nil, secondErr
+		}
+	})
+	ctl := newTestController(Config{Serial: true}, uc)
+
+	var stdout bytes.Buffer
+	err := ctl.ProcessFiles(context.Background(), &stdout, "good.md", "first.md", "second.md")
+	if !errors.Is(err, firstErr) || !errors.Is(err, secondErr) {
+		t.Fatalf("got error %v, want both document errors", err)
+	}
+	for _, path := range []string{"first.md", "second.md"} {
+		if !strings.Contains(err.Error(), path) {
+			t.Errorf("error %q does not contain path %q", err, path)
+		}
+	}
+	if got, want := stdout.String(), "* [Good](#good)\n\n"; got != want {
+		t.Errorf("got output %q, want %q", got, want)
+	}
+}
+
+func TestProcessFilesAcceptsEmptyTOC(t *testing.T) {
+	uc := useCaseFunc(func(context.Context, string) (entity.Toc, error) {
+		return entity.Toc{}, nil
+	})
+	ctl := newTestController(Config{Serial: true}, uc)
+
+	var stdout bytes.Buffer
+	if err := ctl.ProcessFiles(context.Background(), &stdout, "empty.md"); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stdout.String(), "\n"; got != want {
+		t.Errorf("got output %q, want %q", got, want)
+	}
+}
+
+func TestProcessFilesStopsWaitingAfterContextCancellation(t *testing.T) {
+	started := make(chan struct{})
+	uc := useCaseFunc(func(ctx context.Context, _ string) (entity.Toc, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	ctl := newTestController(Config{}, uc)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	go func() {
+		done <- ctl.ProcessFiles(ctx, io.Discard, "slow.md")
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("use case did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got error %v, want context cancellation", err)
+		}
+		if !strings.Contains(err.Error(), "slow.md") {
+			t.Errorf("error %q does not contain the document path", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("controller did not return after context cancellation")
+	}
+}

--- a/internal/controller/file.go
+++ b/internal/controller/file.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
@@ -23,35 +25,62 @@ func (ctl *Controller) getUseCase(file string) useCase {
 	return nil
 }
 
-func (ctl *Controller) ProcessFiles(stdout io.Writer, files ...string) error {
+type processResult struct {
+	path string
+	toc  entity.Toc
+	err  error
+}
+
+func (ctl *Controller) ProcessFiles(ctx context.Context, stdout io.Writer, files ...string) error {
 	ctl.log.Info("Controller.ProcessFiles: start", "files", files)
 	cnt := len(files)
 
-	ch := make(chan *entity.Toc, cnt)
+	ch := make(chan processResult, cnt)
 	for _, file := range files {
 		ctl.log.Info("Controller.ProcessFiles: processing", "file", file)
 		uc := ctl.getUseCase(file)
 		if uc == nil {
-			return errors.New("useCase is null")
+			ch <- processResult{
+				path: file,
+				err:  fmt.Errorf("process %q: select use case: use case is nil", file),
+			}
+			continue
+		}
+
+		process := func(ctx context.Context, uc useCase, path string) processResult {
+			if err := ctx.Err(); err != nil {
+				return processResult{
+					path: path,
+					err:  fmt.Errorf("process %q: %w", path, err),
+				}
+			}
+
+			toc, err := uc.Do(ctx, path)
+			if err != nil {
+				err = fmt.Errorf("process %q: %w", path, err)
+			}
+			return processResult{path: path, toc: toc, err: err}
 		}
 
 		if ctl.cfg.Serial {
-			ch <- uc.Do(file)
+			ch <- process(ctx, uc, file)
 		} else {
-			go func(ucc useCase, path string) {
-				ch <- ucc.Do(path)
-			}(uc, file)
+			go func(ctx context.Context, uc useCase, path string) {
+				ch <- process(ctx, uc, path)
+			}(ctx, uc, file)
 		}
 	}
 
+	var errs []error
 	for i := 0; i < cnt; i++ {
-		toc := <-ch
-		// #14, check if there's really TOC?
-		if toc != nil {
-			if err := toc.Print(stdout); err != nil {
-				return err
-			}
+		result := <-ch
+		if result.err != nil {
+			errs = append(errs, result.err)
+			continue
+		}
+		if err := result.toc.Print(stdout); err != nil {
+			errs = append(errs, fmt.Errorf("print TOC for %q: %w", result.path, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }

--- a/internal/controller/new.go
+++ b/internal/controller/new.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -9,7 +10,7 @@ import (
 )
 
 type useCase interface {
-	Do(string) *entity.Toc
+	Do(context.Context, string) (entity.Toc, error)
 }
 
 type Controller struct {
@@ -30,9 +31,9 @@ func New(cfg Config, ucLocalMD useCase, ucRemoteMD useCase, ucRemoteHTML useCase
 	}
 }
 
-func (ctl *Controller) Process(stdout io.Writer) error {
+func (ctl *Controller) Process(ctx context.Context, stdout io.Writer) error {
 	if len(ctl.cfg.Files) > 0 {
-		return ctl.ProcessFiles(stdout, ctl.cfg.Files...)
+		return ctl.ProcessFiles(ctx, stdout, ctl.cfg.Files...)
 	}
-	return ctl.ProcessSTDIN(stdout, os.Stdin)
+	return ctl.ProcessSTDIN(ctx, stdout, os.Stdin)
 }

--- a/internal/controller/stdin.go
+++ b/internal/controller/stdin.go
@@ -1,20 +1,28 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 )
 
-func (ctl *Controller) ProcessSTDIN(stdout io.Writer, stding *os.File) error {
-	bytes, err := io.ReadAll(stding)
+func (ctl *Controller) ProcessSTDIN(ctx context.Context, stdout io.Writer, stdin io.Reader) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("read standard input: %w", err)
+	}
+
+	bytes, err := io.ReadAll(stdin)
 	if err != nil {
-		return err
+		return fmt.Errorf("read standard input: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("read standard input: %w", err)
 	}
 
 	file, err := os.CreateTemp(os.TempDir(), "ghtoc")
 	if err != nil {
-		return err
+		return fmt.Errorf("create standard input temporary file: %w", err)
 	}
 	defer func() {
 		if err := os.Remove(file.Name()); err != nil {
@@ -24,8 +32,11 @@ func (ctl *Controller) ProcessSTDIN(stdout io.Writer, stding *os.File) error {
 
 	err = os.WriteFile(file.Name(), bytes, 0644)
 	if err != nil {
-		return err
+		return fmt.Errorf("write standard input temporary file %q: %w", file.Name(), err)
 	}
 
-	return ctl.ProcessFiles(stdout, file.Name())
+	if err := ctl.ProcessFiles(ctx, stdout, file.Name()); err != nil {
+		return fmt.Errorf("process standard input: %w", err)
+	}
+	return nil
 }

--- a/internal/core/ports/ports.go
+++ b/internal/core/ports/ports.go
@@ -1,25 +1,26 @@
 package ports
 
 import (
+	"context"
 	"os"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 )
 
 type FileChecker interface {
-	Exists(file string) bool
+	Exists(ctx context.Context, file string) (bool, error)
 }
 
 type FileWriter interface {
-	Write(file string, data []byte) error
+	Write(ctx context.Context, file string, data []byte) error
 }
 
 type HTMLConverter interface {
-	Convert(file string) (string, error)
+	Convert(ctx context.Context, file string) (string, error)
 }
 
 type TocGrabber interface {
-	Grab(html string) (*entity.Toc, error)
+	Grab(ctx context.Context, html string) (*entity.Toc, error)
 }
 
 type Logger interface {
@@ -27,13 +28,13 @@ type Logger interface {
 }
 
 type RemoteGetter interface {
-	Get(path string) ([]byte, string, error)
+	Get(ctx context.Context, path string) ([]byte, string, error)
 }
 
 type FileTemper interface {
-	CreateTemp(dir, pattern string) (*os.File, error)
+	CreateTemp(ctx context.Context, dir, pattern string) (*os.File, error)
 }
 
 type RemotePoster interface {
-	Post(url, token, path string) (string, error)
+	Post(ctx context.Context, url, token, path string) (string, error)
 }

--- a/internal/core/usecase/localmd/localmd.go
+++ b/internal/core/usecase/localmd/localmd.go
@@ -1,6 +1,10 @@
 package localmd
 
 import (
+	"context"
+	"fmt"
+	"io/fs"
+
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
@@ -31,37 +35,48 @@ func New(cfg config.Config, checker ports.FileChecker, writer ports.FileWriter,
 	}
 }
 
-func (uc *LocalMd) Do(file string) *entity.Toc {
+func (uc *LocalMd) Do(ctx context.Context, file string) (entity.Toc, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("process local Markdown %q: %w", file, err)
+	}
+
 	uc.log.Info("LocalMD: Start", "file", file)
-	if !uc.checker.Exists(file) {
+	exists, err := uc.checker.Exists(ctx, file)
+	if err != nil {
+		return nil, fmt.Errorf("check local Markdown %q: %w", file, err)
+	}
+	if !exists {
 		uc.log.Info("LocalMD: local file is not exists.")
-		return nil
+		return nil, fmt.Errorf("open local Markdown %q: %w", file, fs.ErrNotExist)
 	}
 
 	uc.log.Info("LocalMD: converting to html ...")
-	html, err := uc.converter.Convert(file)
+	html, err := uc.converter.Convert(ctx, file)
 	if err != nil {
 		uc.log.Info("LocalMD: Failed to convert MD into HTML: %s", err)
-		return nil
+		return nil, fmt.Errorf("convert local Markdown %q: %w", file, err)
 	}
 
 	if uc.cfg.Debug {
 		htmlFile := file + ".debug.html"
 		uc.log.Info("LocalMD: writing html", "file", htmlFile)
 		// TODO: move to port
-		if err := uc.writer.Write(htmlFile, []byte(html)); err != nil {
+		if err := uc.writer.Write(ctx, htmlFile, []byte(html)); err != nil {
 			uc.log.Info("writing html file error: %s", err)
-			return nil
+			return nil, fmt.Errorf("write debug HTML for %q: %w", file, err)
 		}
 	}
 
 	uc.log.Info("LocalMD: grabbing the TOC ...")
-	toc, err := uc.grabber.Grab(html)
+	toc, err := uc.grabber.Grab(ctx, html)
 	if err != nil {
 		uc.log.Info("LocalMD: failed to grab TOC: %s", err)
-		return nil
+		return nil, fmt.Errorf("grab TOC from local Markdown %q: %w", file, err)
 	}
 
 	uc.log.Info("LocalMD: done.")
-	return toc
+	if toc == nil {
+		return entity.Toc{}, nil
+	}
+	return *toc, nil
 }

--- a/internal/core/usecase/localmd/localmd_test.go
+++ b/internal/core/usecase/localmd/localmd_test.go
@@ -1,0 +1,186 @@
+package localmd
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
+)
+
+type checkerStub struct {
+	exists bool
+	err    error
+}
+
+func (s checkerStub) Exists(context.Context, string) (bool, error) {
+	return s.exists, s.err
+}
+
+type writerStub struct {
+	err error
+}
+
+func (s writerStub) Write(context.Context, string, []byte) error {
+	return s.err
+}
+
+type converterStub struct {
+	html string
+	err  error
+}
+
+func (s converterStub) Convert(context.Context, string) (string, error) {
+	return s.html, s.err
+}
+
+type grabberStub struct {
+	toc *entity.Toc
+	err error
+}
+
+func (s grabberStub) Grab(context.Context, string) (*entity.Toc, error) {
+	return s.toc, s.err
+}
+
+type loggerStub struct{}
+
+func (loggerStub) Info(string, ...any) {}
+
+func TestDoReturnsTOC(t *testing.T) {
+	want := entity.Toc{"* [Title](#title)"}
+	uc := New(
+		config.Config{},
+		checkerStub{exists: true},
+		writerStub{},
+		converterStub{html: "<h1>Title</h1>"},
+		grabberStub{toc: &want},
+		loggerStub{},
+	)
+
+	got, err := uc.Do(context.Background(), "README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("got TOC %v, want %v", got, want)
+	}
+}
+
+func TestDoAcceptsEmptyTOC(t *testing.T) {
+	empty := entity.Toc{}
+	uc := New(
+		config.Config{},
+		checkerStub{exists: true},
+		writerStub{},
+		converterStub{},
+		grabberStub{toc: &empty},
+		loggerStub{},
+	)
+
+	got, err := uc.Do(context.Background(), "empty.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got TOC %v, want an empty TOC", got)
+	}
+}
+
+func TestDoPropagatesDependencyErrors(t *testing.T) {
+	dependencyErr := errors.New("dependency failed")
+	tests := []struct {
+		name      string
+		cfg       config.Config
+		checker   checkerStub
+		writer    writerStub
+		converter converterStub
+		grabber   grabberStub
+		wantText  string
+	}{
+		{
+			name:     "checker",
+			checker:  checkerStub{err: dependencyErr},
+			wantText: "check local Markdown",
+		},
+		{
+			name:      "converter",
+			checker:   checkerStub{exists: true},
+			converter: converterStub{err: dependencyErr},
+			wantText:  "convert local Markdown",
+		},
+		{
+			name:      "debug writer",
+			cfg:       config.Config{Debug: true},
+			checker:   checkerStub{exists: true},
+			converter: converterStub{},
+			writer:    writerStub{err: dependencyErr},
+			wantText:  "write debug HTML",
+		},
+		{
+			name:      "grabber",
+			checker:   checkerStub{exists: true},
+			converter: converterStub{},
+			grabber:   grabberStub{err: dependencyErr},
+			wantText:  "grab TOC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uc := New(tt.cfg, tt.checker, tt.writer, tt.converter, tt.grabber, loggerStub{})
+			_, err := uc.Do(context.Background(), "broken.md")
+			if !errors.Is(err, dependencyErr) {
+				t.Fatalf("got error %v, want dependency error", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantText) {
+				t.Errorf("error %q does not contain %q", err, tt.wantText)
+			}
+			if !strings.Contains(err.Error(), "broken.md") {
+				t.Errorf("error %q does not contain the document path", err)
+			}
+		})
+	}
+}
+
+func TestDoReturnsErrorForMissingFile(t *testing.T) {
+	uc := New(
+		config.Config{},
+		checkerStub{},
+		writerStub{},
+		converterStub{},
+		grabberStub{},
+		loggerStub{},
+	)
+
+	_, err := uc.Do(context.Background(), "missing.md")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("got error %v, want fs.ErrNotExist", err)
+	}
+	if !strings.Contains(err.Error(), "missing.md") {
+		t.Errorf("error %q does not contain the document path", err)
+	}
+}
+
+func TestDoReturnsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	uc := New(
+		config.Config{},
+		checkerStub{exists: true},
+		writerStub{},
+		converterStub{},
+		grabberStub{},
+		loggerStub{},
+	)
+
+	_, err := uc.Do(ctx, "README.md")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got error %v, want context cancellation", err)
+	}
+}

--- a/internal/core/usecase/remotehtml/remotehtml.go
+++ b/internal/core/usecase/remotehtml/remotehtml.go
@@ -1,6 +1,9 @@
 package remotehtml
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
@@ -22,20 +25,24 @@ func New(cfg config.Config, getter ports.RemoteGetter, writer ports.FileWriter,
 	return &RemoteHTML{cfg, getter, grabber, writer, temper, log}
 }
 
-func (r *RemoteHTML) Do(url string) *entity.Toc {
+func (r *RemoteHTML) Do(ctx context.Context, url string) (entity.Toc, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("process remote HTML %q: %w", url, err)
+	}
+
 	r.log.Info("RemoteHTML: start, downloading remote file ...", "url", url)
-	jsonBody, ContentType, err := r.getter.Get(url)
+	jsonBody, contentType, err := r.getter.Get(ctx, url)
 	if err != nil {
 		r.log.Info("RemoteHTML: download fail", "err", err)
-		return nil
+		return nil, fmt.Errorf("get remote HTML %q: %w", url, err)
 	}
-	r.log.Info("RemoteHTML: got file", "content-type=", ContentType)
+	r.log.Info("RemoteHTML: got file", "content-type=", contentType)
 
 	if r.cfg.Debug {
-		tmpfile, err := r.tempter.CreateTemp("", "ghtoc-remote-json-*")
+		tmpfile, err := r.tempter.CreateTemp(ctx, "", "ghtoc-remote-json-*")
 		if err != nil {
 			r.log.Info("RemoteHTML: creating file failed", "err", err)
-			return nil
+			return nil, fmt.Errorf("create debug file for %q: %w", url, err)
 		}
 		defer func() {
 			if err := tmpfile.Close(); err != nil {
@@ -46,19 +53,22 @@ func (r *RemoteHTML) Do(url string) *entity.Toc {
 
 		jsonFile := path + ".debug.json"
 		r.log.Info("RemoteHTML: writing json file", "path", jsonFile)
-		if err := r.writer.Write(jsonFile, jsonBody); err != nil {
+		if err := r.writer.Write(ctx, jsonFile, jsonBody); err != nil {
 			r.log.Info("RemoteHTML: writing json file failed", "err", err)
-			return nil
+			return nil, fmt.Errorf("write debug JSON for %q: %w", url, err)
 		}
 	}
 
 	r.log.Info("RemoteHTML: grabbing the TOC ...")
-	toc, err := r.grabber.Grab(string(jsonBody))
+	toc, err := r.grabber.Grab(ctx, string(jsonBody))
 	if err != nil {
 		r.log.Info("RemoteHTML: failed to grab TOC", "err", err)
-		return nil
+		return nil, fmt.Errorf("grab TOC from remote HTML %q: %w", url, err)
 	}
 
 	r.log.Info("RemoteHTML: done.")
-	return toc
+	if toc == nil {
+		return entity.Toc{}, nil
+	}
+	return *toc, nil
 }

--- a/internal/core/usecase/remotehtml/remotehtml_test.go
+++ b/internal/core/usecase/remotehtml/remotehtml_test.go
@@ -1,0 +1,179 @@
+package remotehtml
+
+import (
+	"context"
+	"errors"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
+)
+
+type getterStub struct {
+	body        []byte
+	contentType string
+	err         error
+}
+
+func (s getterStub) Get(context.Context, string) ([]byte, string, error) {
+	return s.body, s.contentType, s.err
+}
+
+type writerStub struct {
+	err error
+}
+
+func (s writerStub) Write(context.Context, string, []byte) error {
+	return s.err
+}
+
+type temperStub struct {
+	create func(context.Context, string, string) (*os.File, error)
+}
+
+func (s temperStub) CreateTemp(ctx context.Context, dir, pattern string) (*os.File, error) {
+	return s.create(ctx, dir, pattern)
+}
+
+type grabberStub struct {
+	toc *entity.Toc
+	err error
+}
+
+func (s grabberStub) Grab(context.Context, string) (*entity.Toc, error) {
+	return s.toc, s.err
+}
+
+type loggerStub struct{}
+
+func (loggerStub) Info(string, ...any) {}
+
+func createTemper(t *testing.T) temperStub {
+	t.Helper()
+	return temperStub{
+		create: func(_ context.Context, _, pattern string) (*os.File, error) {
+			return os.CreateTemp(t.TempDir(), pattern)
+		},
+	}
+}
+
+func TestDoReturnsTOC(t *testing.T) {
+	want := entity.Toc{"* [Title](#title)"}
+	uc := New(
+		config.Config{},
+		getterStub{body: []byte(`{"payload":{}}`), contentType: "application/json"},
+		writerStub{},
+		createTemper(t),
+		grabberStub{toc: &want},
+		loggerStub{},
+	)
+
+	got, err := uc.Do(context.Background(), "https://github.com/example/repo/blob/main/README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("got TOC %v, want %v", got, want)
+	}
+}
+
+func TestDoPropagatesDownloadError(t *testing.T) {
+	dependencyErr := errors.New("download failed")
+	uc := New(
+		config.Config{},
+		getterStub{err: dependencyErr},
+		writerStub{},
+		createTemper(t),
+		grabberStub{},
+		loggerStub{},
+	)
+
+	const documentURL = "https://github.com/example/repo/blob/main/README.md"
+	_, err := uc.Do(context.Background(), documentURL)
+	if !errors.Is(err, dependencyErr) {
+		t.Fatalf("got error %v, want download error", err)
+	}
+	if !strings.Contains(err.Error(), documentURL) {
+		t.Errorf("error %q does not contain the document URL", err)
+	}
+}
+
+func TestDoPropagatesGrabberError(t *testing.T) {
+	dependencyErr := errors.New("grab failed")
+	uc := New(
+		config.Config{},
+		getterStub{body: []byte(`{"payload":{}}`)},
+		writerStub{},
+		createTemper(t),
+		grabberStub{err: dependencyErr},
+		loggerStub{},
+	)
+
+	_, err := uc.Do(context.Background(), "https://github.com/example/repo/blob/main/README.md")
+	if !errors.Is(err, dependencyErr) {
+		t.Fatalf("got error %v, want grabber error", err)
+	}
+}
+
+func TestDoPropagatesDebugFileErrors(t *testing.T) {
+	dependencyErr := errors.New("debug file failed")
+	tests := []struct {
+		name   string
+		temper temperStub
+		writer writerStub
+	}{
+		{
+			name: "create",
+			temper: temperStub{
+				create: func(context.Context, string, string) (*os.File, error) {
+					return nil, dependencyErr
+				},
+			},
+		},
+		{
+			name:   "write",
+			temper: createTemper(t),
+			writer: writerStub{err: dependencyErr},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uc := New(
+				config.Config{Debug: true},
+				getterStub{body: []byte(`{"payload":{}}`)},
+				tt.writer,
+				tt.temper,
+				grabberStub{},
+				loggerStub{},
+			)
+
+			_, err := uc.Do(context.Background(), "https://github.com/example/repo/blob/main/README.md")
+			if !errors.Is(err, dependencyErr) {
+				t.Fatalf("got error %v, want debug file error", err)
+			}
+		})
+	}
+}
+
+func TestDoReturnsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	uc := New(
+		config.Config{},
+		getterStub{},
+		writerStub{},
+		createTemper(t),
+		grabberStub{},
+		loggerStub{},
+	)
+
+	_, err := uc.Do(ctx, "https://github.com/example/repo/blob/main/README.md")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got error %v, want context cancellation", err)
+	}
+}

--- a/internal/core/usecase/remotemd/remotemd.go
+++ b/internal/core/usecase/remotemd/remotemd.go
@@ -1,6 +1,8 @@
 package remotemd
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
@@ -25,24 +27,24 @@ func New(cfg config.Config, getter ports.RemoteGetter, localMD *localmd.LocalMd,
 	return &RemoteMd{cfg, localMD, getter, temper, writer, log}
 }
 
-func (r *RemoteMd) download(url string) (string, error) {
-	body, ContentType, err := r.getter.Get(url)
+func (r *RemoteMd) download(ctx context.Context, url string) (string, error) {
+	body, contentType, err := r.getter.Get(ctx, url)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("get remote Markdown %q: %w", url, err)
 	}
 
 	// if not a plain text - it's an error
-	if strings.Split(ContentType, ";")[0] != "text/plain" {
-		r.log.Info("RemoteMD: not a plain text, stop.", "content-type", ContentType)
-		return "", err
+	if strings.Split(contentType, ";")[0] != "text/plain" {
+		r.log.Info("RemoteMD: not a plain text, stop.", "content-type", contentType)
+		return "", fmt.Errorf("get remote Markdown %q: unexpected content type %q", url, contentType)
 	}
 
 	// if remote file's content is a plain text
 	// we need to convert it to html
-	tmpfile, err := r.temper.CreateTemp("", "ghtoc-remote-txt-*")
+	tmpfile, err := r.temper.CreateTemp(ctx, "", "ghtoc-remote-txt-*")
 	if err != nil {
 		r.log.Info("RemoteMD: creating tmp file failed.", "err", err)
-		return "", err
+		return "", fmt.Errorf("create temporary file for %q: %w", url, err)
 	}
 	defer func() {
 		if err := tmpfile.Close(); err != nil {
@@ -52,18 +54,26 @@ func (r *RemoteMd) download(url string) (string, error) {
 
 	path := tmpfile.Name()
 	r.log.Info("RemoteMD: save content into tmp file", "path", path)
-	if err = r.writer.Write(tmpfile.Name(), body); err != nil {
+	if err = r.writer.Write(ctx, tmpfile.Name(), body); err != nil {
 		r.log.Info("RemoteMD: writing file failed.", "err", err)
-		return "", err
+		return "", fmt.Errorf("write temporary file for %q: %w", url, err)
 	}
 	return path, nil
 }
 
-func (r *RemoteMd) Do(url string) *entity.Toc {
-	filename, err := r.download(url)
+func (r *RemoteMd) Do(ctx context.Context, url string) (entity.Toc, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("process remote Markdown %q: %w", url, err)
+	}
+
+	filename, err := r.download(ctx, url)
 	if err != nil {
 		r.log.Info("RemoteMD: download fail", "err", err)
-		return nil
+		return nil, err
 	}
-	return r.ucLocalMD.Do(filename)
+	toc, err := r.ucLocalMD.Do(ctx, filename)
+	if err != nil {
+		return nil, fmt.Errorf("process remote Markdown %q: %w", url, err)
+	}
+	return toc, nil
 }

--- a/internal/core/usecase/remotemd/remotemd_test.go
+++ b/internal/core/usecase/remotemd/remotemd_test.go
@@ -1,0 +1,214 @@
+package remotemd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/config"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/localmd"
+)
+
+type getterStub struct {
+	body        []byte
+	contentType string
+	err         error
+}
+
+func (s getterStub) Get(context.Context, string) ([]byte, string, error) {
+	return s.body, s.contentType, s.err
+}
+
+type temperStub struct {
+	create func(context.Context, string, string) (*os.File, error)
+}
+
+func (s temperStub) CreateTemp(ctx context.Context, dir, pattern string) (*os.File, error) {
+	return s.create(ctx, dir, pattern)
+}
+
+type writerStub struct {
+	err error
+}
+
+func (s writerStub) Write(context.Context, string, []byte) error {
+	return s.err
+}
+
+type checkerStub struct {
+	exists bool
+}
+
+func (s checkerStub) Exists(context.Context, string) (bool, error) {
+	return s.exists, nil
+}
+
+type converterStub struct {
+	err error
+}
+
+func (s converterStub) Convert(context.Context, string) (string, error) {
+	return "<h1>Title</h1>", s.err
+}
+
+type grabberStub struct {
+	toc *entity.Toc
+	err error
+}
+
+func (s grabberStub) Grab(context.Context, string) (*entity.Toc, error) {
+	return s.toc, s.err
+}
+
+type loggerStub struct{}
+
+func (loggerStub) Info(string, ...any) {}
+
+func createTemper(t *testing.T) temperStub {
+	t.Helper()
+	return temperStub{
+		create: func(_ context.Context, _, pattern string) (*os.File, error) {
+			return os.CreateTemp(t.TempDir(), pattern)
+		},
+	}
+}
+
+func newUseCase(
+	t *testing.T,
+	getter getterStub,
+	temper temperStub,
+	writer writerStub,
+	converter converterStub,
+	grabber grabberStub,
+) *RemoteMd {
+	t.Helper()
+	local := localmd.New(
+		config.Config{},
+		checkerStub{exists: true},
+		writer,
+		converter,
+		grabber,
+		loggerStub{},
+	)
+	return New(config.Config{}, getter, local, temper, writer, loggerStub{})
+}
+
+func TestDoReturnsTOC(t *testing.T) {
+	want := entity.Toc{"* [Title](#title)"}
+	uc := newUseCase(
+		t,
+		getterStub{body: []byte("# Title"), contentType: "text/plain"},
+		createTemper(t),
+		writerStub{},
+		converterStub{},
+		grabberStub{toc: &want},
+	)
+
+	got, err := uc.Do(context.Background(), "https://example.com/README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("got TOC %v, want %v", got, want)
+	}
+}
+
+func TestDoPropagatesDownloadError(t *testing.T) {
+	dependencyErr := errors.New("download failed")
+	uc := newUseCase(
+		t,
+		getterStub{err: dependencyErr},
+		createTemper(t),
+		writerStub{},
+		converterStub{},
+		grabberStub{},
+	)
+
+	const documentURL = "https://example.com/README.md"
+	_, err := uc.Do(context.Background(), documentURL)
+	if !errors.Is(err, dependencyErr) {
+		t.Fatalf("got error %v, want download error", err)
+	}
+	if !strings.Contains(err.Error(), documentURL) {
+		t.Errorf("error %q does not contain the document URL", err)
+	}
+}
+
+func TestDoPropagatesTemporaryFileError(t *testing.T) {
+	dependencyErr := errors.New("temporary file failed")
+	uc := newUseCase(
+		t,
+		getterStub{body: []byte("# Title"), contentType: "text/plain"},
+		temperStub{
+			create: func(context.Context, string, string) (*os.File, error) {
+				return nil, dependencyErr
+			},
+		},
+		writerStub{},
+		converterStub{},
+		grabberStub{},
+	)
+
+	_, err := uc.Do(context.Background(), "https://example.com/README.md")
+	if !errors.Is(err, dependencyErr) {
+		t.Fatalf("got error %v, want temporary file error", err)
+	}
+}
+
+func TestDoPropagatesWriterError(t *testing.T) {
+	dependencyErr := errors.New("write failed")
+	uc := newUseCase(
+		t,
+		getterStub{body: []byte("# Title"), contentType: "text/plain"},
+		createTemper(t),
+		writerStub{err: dependencyErr},
+		converterStub{},
+		grabberStub{},
+	)
+
+	_, err := uc.Do(context.Background(), "https://example.com/README.md")
+	if !errors.Is(err, dependencyErr) {
+		t.Fatalf("got error %v, want writer error", err)
+	}
+}
+
+func TestDoKeepsRemotePathForLocalProcessingError(t *testing.T) {
+	dependencyErr := errors.New("convert failed")
+	uc := newUseCase(
+		t,
+		getterStub{body: []byte("# Title"), contentType: "text/plain"},
+		createTemper(t),
+		writerStub{},
+		converterStub{err: dependencyErr},
+		grabberStub{},
+	)
+
+	const documentURL = "https://example.com/README.md"
+	_, err := uc.Do(context.Background(), documentURL)
+	if !errors.Is(err, dependencyErr) {
+		t.Fatalf("got error %v, want converter error", err)
+	}
+	if !strings.Contains(err.Error(), documentURL) {
+		t.Errorf("error %q does not contain the original document URL", err)
+	}
+}
+
+func TestDoRejectsUnexpectedContentType(t *testing.T) {
+	uc := newUseCase(
+		t,
+		getterStub{body: []byte("<html></html>"), contentType: "text/html"},
+		createTemper(t),
+		writerStub{},
+		converterStub{},
+		grabberStub{},
+	)
+
+	_, err := uc.Do(context.Background(), "https://example.com/README.md")
+	if err == nil {
+		t.Fatal("expected an error for an unexpected content type")
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -37,26 +38,26 @@ func doHTTPReq(req *http.Request) ([]byte, string, error) {
 }
 
 // HttpGet executes HTTP GET request.
-func HttpGet(urlPath string) ([]byte, string, error) {
-	req, err := http.NewRequest("GET", urlPath, nil)
+func HttpGet(ctx context.Context, urlPath string) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlPath, nil)
 	if err != nil {
 		return []byte{}, "", err
 	}
 	return doHTTPReq(req)
 }
 
-func HttpGetJson(urlPath string) ([]byte, string, error) {
-	req, err := http.NewRequest("GET", urlPath, nil)
-	req.Header.Set("Content-type", "application/json")
-	req.Header.Set("Accept", "application/json")
+func HttpGetJson(ctx context.Context, urlPath string) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlPath, nil)
 	if err != nil {
 		return []byte{}, "", err
 	}
+	req.Header.Set("Content-type", "application/json")
+	req.Header.Set("Accept", "application/json")
 	return doHTTPReq(req)
 }
 
 // HttpPost executes HTTP POST with file content.
-func HttpPost(url, path, token string) (string, error) {
+func HttpPost(ctx context.Context, url, path, token string) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return "", err
@@ -71,7 +72,7 @@ func HttpPost(url, path, token string) (string, error) {
 		return "", err
 	}
 
-	req, err := http.NewRequest("POST", url, body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
 		return "", err
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -2,12 +2,15 @@ package utils
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
@@ -27,7 +30,7 @@ func TestHttpGet(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	body, _, err := HttpGet(srv.URL)
+	body, _, err := HttpGet(context.Background(), srv.URL)
 	got := string(body)
 
 	if err != nil {
@@ -62,7 +65,7 @@ func TestHttpGetJson(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	body, _, err := HttpGetJson(srv.URL)
+	body, _, err := HttpGetJson(context.Background(), srv.URL)
 	got := string(body)
 
 	if err != nil {
@@ -84,7 +87,7 @@ func TestHttpGetForbidden(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, _, err := HttpGet(srv.URL)
+	_, _, err := HttpGet(context.Background(), srv.URL)
 	if err == nil {
 		t.Error("Should not not be nil")
 	}
@@ -131,9 +134,53 @@ func TestHttpPost(t *testing.T) {
 		_ = os.Remove(fileName)
 	}()
 
-	_, err = HttpPost(srv.URL, fileName, token)
+	_, err = HttpPost(context.Background(), srv.URL, fileName, token)
 	if err != nil {
 		t.Error("Should not be err", err)
+	}
+}
+
+func TestHttpPostCancelsInFlightRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(started)
+		<-release
+	}))
+	defer func() {
+		close(release)
+		srv.Close()
+	}()
+
+	fileName, err := createTmp("# some title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Remove(fileName)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := HttpPost(ctx, srv.URL, fileName, "")
+		done <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP request did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got error %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HTTP request was not canceled")
 	}
 }
 


### PR DESCRIPTION
## Summary

- propagate `context.Context` from the CLI entry point through app, controller, use cases, ports, and HTTP requests
- return explicit use case errors instead of encoding failures as nil TOCs
- aggregate document errors while preserving successful output
- return a non-zero exit code and omit the footer when processing fails
- add tests for dependency failures, missing files, empty TOCs, context cancellation, and partial success

## Checks

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `GOTOOLCHAIN=go1.21.13 go test ./...`
- `go vet ./...`
- `golangci-lint run`
- `go mod tidy -diff`