### PR TITLE
fix(http): harden requests and resource cleanup

### DIFF
--- a/internal/adapters/filetemper.go
+++ b/internal/adapters/filetemper.go
@@ -18,3 +18,7 @@ func (f *FileTemper) CreateTemp(ctx context.Context, dir, pattern string) (*os.F
 	}
 	return os.CreateTemp(dir, pattern)
 }
+
+func (f *FileTemper) Remove(path string) error {
+	return os.Remove(path)
+}

--- a/internal/adapters/filetemper_test.go
+++ b/internal/adapters/filetemper_test.go
@@ -2,6 +2,8 @@ package adapters
 
 import (
 	"context"
+	"errors"
+	"os"
 	"testing"
 )
 
@@ -16,9 +18,12 @@ func Test_FileTemper(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			f, err := temper.CreateTemp(ctx, "", "gh-toc-tests-*")
+			f, err := temper.CreateTemp(ctx, t.TempDir(), "gh-toc-tests-*")
 			if err != nil {
 				t.Errorf("Got err=%v", err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
 			}
 			exists, err := checker.Exists(ctx, f.Name())
 			if err != nil {
@@ -26,6 +31,12 @@ func Test_FileTemper(t *testing.T) {
 			}
 			if !exists {
 				t.Errorf("File not exists, f=%v", f.Name())
+			}
+			if err := temper.Remove(f.Name()); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(f.Name()); !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("temporary file still exists: %v", err)
 			}
 		})
 	}

--- a/internal/adapters/filewriter_test.go
+++ b/internal/adapters/filewriter_test.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -16,7 +17,7 @@ func Test_FileWriter(t *testing.T) {
 	checker := NewFileCheck(NewLogger(false))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			file := "./tmp-for-test"
+			file := filepath.Join(t.TempDir(), "tmp-for-test")
 			test_data := "some-test"
 			ctx := context.Background()
 			err := writer.Write(ctx, file, []byte(test_data))

--- a/internal/adapters/htmlconverter.go
+++ b/internal/adapters/htmlconverter.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 )
@@ -14,7 +15,11 @@ type HTMLConverter struct {
 }
 
 func NewHTMLConverter(token, url string, log ports.Logger) *HTMLConverter {
-	return NewHTMLConverterX(token, url, NewRemotePoster(), log)
+	return NewHTMLConverterWithClient(token, url, NewHTTPClient(), log)
+}
+
+func NewHTMLConverterWithClient(token, url string, client *http.Client, log ports.Logger) *HTMLConverter {
+	return NewHTMLConverterX(token, url, NewRemotePosterWithClient(client), log)
 }
 
 func NewHTMLConverterX(token, url string, poster ports.RemotePoster, log ports.Logger) *HTMLConverter {

--- a/internal/adapters/httpclient.go
+++ b/internal/adapters/httpclient.go
@@ -1,0 +1,12 @@
+package adapters
+
+import (
+	"net/http"
+	"time"
+)
+
+const defaultHTTPTimeout = 30 * time.Second
+
+func NewHTTPClient() *http.Client {
+	return &http.Client{Timeout: defaultHTTPTimeout}
+}

--- a/internal/adapters/httpclient_test.go
+++ b/internal/adapters/httpclient_test.go
@@ -1,0 +1,27 @@
+package adapters
+
+import "testing"
+
+func TestNewHTTPClientHasTimeout(t *testing.T) {
+	client := NewHTTPClient()
+	if client.Timeout != defaultHTTPTimeout {
+		t.Fatalf("got timeout %s, want %s", client.Timeout, defaultHTTPTimeout)
+	}
+}
+
+func TestRemoteAdaptersUseInjectedHTTPClient(t *testing.T) {
+	client := NewHTTPClient()
+	getter := NewRemoteGetterWithClient(true, client)
+	if getter.client != client {
+		t.Fatal("remote getter does not use the injected HTTP client")
+	}
+
+	poster := NewRemotePosterWithClient(client)
+	real, ok := poster.poster.(*realPoster)
+	if !ok {
+		t.Fatalf("got poster type %T, want *realPoster", poster.poster)
+	}
+	if real.client != client {
+		t.Fatal("remote poster does not use the injected HTTP client")
+	}
+}

--- a/internal/adapters/remoteposter.go
+++ b/internal/adapters/remoteposter.go
@@ -2,19 +2,21 @@ package adapters
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
 )
 
 type realPoster struct {
+	client *http.Client
 }
 
 func (p *realPoster) Post(ctx context.Context, url, token, path string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
-	return utils.HttpPost(ctx, url, path, token)
+	return utils.HttpPost(ctx, p.client, url, path, token)
 }
 
 type RemotePoster struct {
@@ -22,7 +24,11 @@ type RemotePoster struct {
 }
 
 func NewRemotePoster() *RemotePoster {
-	return NewRemotePosterX(&realPoster{})
+	return NewRemotePosterWithClient(NewHTTPClient())
+}
+
+func NewRemotePosterWithClient(client *http.Client) *RemotePoster {
+	return NewRemotePosterX(&realPoster{client: client})
 }
 
 func NewRemotePosterX(poster ports.RemotePoster) *RemotePoster {

--- a/internal/adapters/remoteposter_test.go
+++ b/internal/adapters/remoteposter_test.go
@@ -31,9 +31,12 @@ func Test_RemotePoster(t *testing.T) {
 				}
 			} else {
 				testToken := "token-for-test"
-				fileName, err := NewFileTemper().CreateTemp(ctx, "", "example.*.txt")
+				fileName, err := NewFileTemper().CreateTemp(ctx, t.TempDir(), "example.*.txt")
 				if err != nil {
 					t.Error("Tmp file creation err=", err)
+				}
+				if err := fileName.Close(); err != nil {
+					t.Fatal(err)
 				}
 				defer func() {
 					if err := os.Remove(fileName.Name()); err != nil {

--- a/internal/adapters/remotergetter.go
+++ b/internal/adapters/remotergetter.go
@@ -2,16 +2,25 @@ package adapters
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/utils"
 )
 
 type RemoteGetter struct {
+	client *http.Client
 	asJSON bool
 }
 
 func NewRemoteGetter(asJSON bool) *RemoteGetter {
-	return &RemoteGetter{asJSON: asJSON}
+	return NewRemoteGetterWithClient(asJSON, NewHTTPClient())
+}
+
+func NewRemoteGetterWithClient(asJSON bool, client *http.Client) *RemoteGetter {
+	return &RemoteGetter{
+		client: client,
+		asJSON: asJSON,
+	}
 }
 
 func (r *RemoteGetter) Get(ctx context.Context, path string) ([]byte, string, error) {
@@ -19,7 +28,7 @@ func (r *RemoteGetter) Get(ctx context.Context, path string) ([]byte, string, er
 		return nil, "", err
 	}
 	if r.asJSON {
-		return utils.HttpGetJson(ctx, path)
+		return utils.HttpGetJson(ctx, r.client, path)
 	}
-	return utils.HttpGet(ctx, path)
+	return utils.HttpGet(ctx, r.client, path)
 }

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -39,15 +39,16 @@ func New(cfg Config) (*App, error) {
 	ucCfg := ctlCfg.ToUseCaseConfig()
 
 	log.Info("App.New: init adapters ...")
+	httpClient := adapters.NewHTTPClient()
 	checker := adapters.NewFileCheck(log)
 	writer := adapters.NewFileWriter(log)
-	converter := adapters.NewHTMLConverter(cfg.GHToken, cfg.GHUrl, log)
+	converter := adapters.NewHTMLConverterWithClient(cfg.GHToken, cfg.GHUrl, httpClient, log)
 	grabberRe, err := adapters.NewReGrabber("", cfg.ToGrabberConfig(), cfg.GHVersion)
 	if err != nil {
 		return nil, fmt.Errorf("initialize regexp grabber: %w", err)
 	}
 	grabberJson := adapters.NewJsonGrabber(cfg.ToGrabberConfig())
-	getter := adapters.NewRemoteGetter(true)
+	getter := adapters.NewRemoteGetterWithClient(true, httpClient)
 	temper := adapters.NewFileTemper()
 
 	log.Info("App.New: init usecases ...")

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -103,5 +105,52 @@ func TestProcessFilesStopsWaitingAfterContextCancellation(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("controller did not return after context cancellation")
+	}
+}
+
+func TestProcessSTDINCleansUpTemporaryFile(t *testing.T) {
+	processingErr := errors.New("processing failed")
+	tests := []struct {
+		name    string
+		ucError error
+	}{
+		{name: "success"},
+		{name: "processing error", ucError: processingErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tempPath string
+			uc := useCaseFunc(func(_ context.Context, path string) (entity.Toc, error) {
+				tempPath = path
+				body, err := os.ReadFile(path)
+				if err != nil {
+					return nil, err
+				}
+				if got, want := string(body), "# Title"; got != want {
+					return nil, fmt.Errorf("got stdin body %q, want %q", got, want)
+				}
+				return entity.Toc{}, tt.ucError
+			})
+			ctl := newTestController(Config{Serial: true}, uc)
+
+			err := ctl.ProcessSTDIN(
+				context.Background(),
+				io.Discard,
+				strings.NewReader("# Title"),
+			)
+			if tt.ucError == nil && err != nil {
+				t.Fatal(err)
+			}
+			if tt.ucError != nil && !errors.Is(err, tt.ucError) {
+				t.Fatalf("got error %v, want processing error", err)
+			}
+			if tempPath == "" {
+				t.Fatal("use case did not receive a temporary file")
+			}
+			if _, statErr := os.Stat(tempPath); !errors.Is(statErr, os.ErrNotExist) {
+				t.Errorf("stdin temporary file still exists: %v", statErr)
+			}
+		})
 	}
 }

--- a/internal/controller/stdin.go
+++ b/internal/controller/stdin.go
@@ -2,12 +2,13 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 )
 
-func (ctl *Controller) ProcessSTDIN(ctx context.Context, stdout io.Writer, stdin io.Reader) error {
+func (ctl *Controller) ProcessSTDIN(ctx context.Context, stdout io.Writer, stdin io.Reader) (err error) {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("read standard input: %w", err)
 	}
@@ -24,18 +25,33 @@ func (ctl *Controller) ProcessSTDIN(ctx context.Context, stdout io.Writer, stdin
 	if err != nil {
 		return fmt.Errorf("create standard input temporary file: %w", err)
 	}
+	path := file.Name()
+	fileOpen := true
 	defer func() {
-		if err := os.Remove(file.Name()); err != nil {
-			_, _ = fmt.Fprintln(stdout, "Error during file delete:", err)
+		if fileOpen {
+			if closeErr := file.Close(); closeErr != nil {
+				err = errors.Join(err, fmt.Errorf("close standard input temporary file %q: %w", path, closeErr))
+			}
+		}
+		if removeErr := os.Remove(path); removeErr != nil {
+			err = errors.Join(err, fmt.Errorf("remove standard input temporary file %q: %w", path, removeErr))
 		}
 	}()
 
-	err = os.WriteFile(file.Name(), bytes, 0644)
+	written, err := file.Write(bytes)
 	if err != nil {
-		return fmt.Errorf("write standard input temporary file %q: %w", file.Name(), err)
+		return fmt.Errorf("write standard input temporary file %q: %w", path, err)
+	}
+	if written != len(bytes) {
+		return fmt.Errorf("write standard input temporary file %q: %w", path, io.ErrShortWrite)
+	}
+	closeErr := file.Close()
+	fileOpen = false
+	if closeErr != nil {
+		return fmt.Errorf("close standard input temporary file %q: %w", path, closeErr)
 	}
 
-	if err := ctl.ProcessFiles(ctx, stdout, file.Name()); err != nil {
+	if err := ctl.ProcessFiles(ctx, stdout, path); err != nil {
 		return fmt.Errorf("process standard input: %w", err)
 	}
 	return nil

--- a/internal/core/ports/ports.go
+++ b/internal/core/ports/ports.go
@@ -33,6 +33,7 @@ type RemoteGetter interface {
 
 type FileTemper interface {
 	CreateTemp(ctx context.Context, dir, pattern string) (*os.File, error)
+	Remove(path string) error
 }
 
 type RemotePoster interface {

--- a/internal/core/usecase/new.go
+++ b/internal/core/usecase/new.go
@@ -19,8 +19,8 @@ func New(cfg config.Config,
 	log ports.Logger) (*localmd.LocalMd, *remotemd.RemoteMd, *remotehtml.RemoteHTML) {
 
 	ucLocalMD := localmd.New(cfg, checker, writer, converter, grabberRe, log)
-	ucRemoteMD := remotemd.New(cfg, getter, ucLocalMD, temper, writer, log)
-	ucRemoteHTML := remotehtml.New(cfg, getter, writer, temper, grabberJson, log)
+	ucRemoteMD := remotemd.New(cfg, getter, ucLocalMD, temper, log)
+	ucRemoteHTML := remotehtml.New(cfg, getter, temper, grabberJson, log)
 
 	return ucLocalMD, ucRemoteMD, ucRemoteHTML
 }

--- a/internal/core/usecase/remotehtml/remotehtml.go
+++ b/internal/core/usecase/remotehtml/remotehtml.go
@@ -2,7 +2,10 @@ package remotehtml
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"mime"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
@@ -15,14 +18,42 @@ type RemoteHTML struct {
 	cfg     config.Config
 	getter  ports.RemoteGetter
 	grabber ports.TocGrabber
-	writer  ports.FileWriter
 	tempter ports.FileTemper
 	log     ports.Logger
 }
 
-func New(cfg config.Config, getter ports.RemoteGetter, writer ports.FileWriter,
+func New(cfg config.Config, getter ports.RemoteGetter,
 	temper ports.FileTemper, grabber ports.TocGrabber, log ports.Logger) *RemoteHTML {
-	return &RemoteHTML{cfg, getter, grabber, writer, temper, log}
+	return &RemoteHTML{cfg, getter, grabber, temper, log}
+}
+
+func (r *RemoteHTML) writeDebugFile(ctx context.Context, url string, body []byte) (path string, err error) {
+	tmpfile, err := r.tempter.CreateTemp(ctx, "", "ghtoc-remote-*.debug.json")
+	if err != nil {
+		return "", fmt.Errorf("create debug file for %q: %w", url, err)
+	}
+	tempPath := tmpfile.Name()
+	path = tempPath
+	defer func() {
+		if closeErr := tmpfile.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close debug file for %q: %w", url, closeErr))
+		}
+		if err != nil {
+			if removeErr := r.tempter.Remove(tempPath); removeErr != nil {
+				err = errors.Join(err, fmt.Errorf("remove debug file for %q: %w", url, removeErr))
+			}
+			path = ""
+		}
+	}()
+
+	written, err := tmpfile.Write(body)
+	if err != nil {
+		return "", fmt.Errorf("write debug JSON for %q: %w", url, err)
+	}
+	if written != len(body) {
+		return "", fmt.Errorf("write debug JSON for %q: %w", url, io.ErrShortWrite)
+	}
+	return path, nil
 }
 
 func (r *RemoteHTML) Do(ctx context.Context, url string) (entity.Toc, error) {
@@ -38,25 +69,21 @@ func (r *RemoteHTML) Do(ctx context.Context, url string) (entity.Toc, error) {
 	}
 	r.log.Info("RemoteHTML: got file", "content-type=", contentType)
 
-	if r.cfg.Debug {
-		tmpfile, err := r.tempter.CreateTemp(ctx, "", "ghtoc-remote-json-*")
-		if err != nil {
-			r.log.Info("RemoteHTML: creating file failed", "err", err)
-			return nil, fmt.Errorf("create debug file for %q: %w", url, err)
-		}
-		defer func() {
-			if err := tmpfile.Close(); err != nil {
-				r.log.Info("RemoteHTML: closing file failed", "err", err)
-			}
-		}()
-		path := tmpfile.Name()
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, fmt.Errorf("parse content type for remote HTML %q: %w", url, err)
+	}
+	if mediaType != "application/json" {
+		return nil, fmt.Errorf("get remote HTML %q: unexpected content type %q", url, contentType)
+	}
 
-		jsonFile := path + ".debug.json"
-		r.log.Info("RemoteHTML: writing json file", "path", jsonFile)
-		if err := r.writer.Write(ctx, jsonFile, jsonBody); err != nil {
+	if r.cfg.Debug {
+		debugFile, err := r.writeDebugFile(ctx, url, jsonBody)
+		if err != nil {
 			r.log.Info("RemoteHTML: writing json file failed", "err", err)
-			return nil, fmt.Errorf("write debug JSON for %q: %w", url, err)
+			return nil, err
 		}
+		r.log.Info("RemoteHTML: wrote debug JSON", "path", debugFile)
 	}
 
 	r.log.Info("RemoteHTML: grabbing the TOC ...")

--- a/internal/core/usecase/remotehtml/remotehtml_test.go
+++ b/internal/core/usecase/remotehtml/remotehtml_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -22,20 +23,20 @@ func (s getterStub) Get(context.Context, string) ([]byte, string, error) {
 	return s.body, s.contentType, s.err
 }
 
-type writerStub struct {
-	err error
-}
-
-func (s writerStub) Write(context.Context, string, []byte) error {
-	return s.err
-}
-
 type temperStub struct {
 	create func(context.Context, string, string) (*os.File, error)
+	remove func(string) error
 }
 
 func (s temperStub) CreateTemp(ctx context.Context, dir, pattern string) (*os.File, error) {
 	return s.create(ctx, dir, pattern)
+}
+
+func (s temperStub) Remove(path string) error {
+	if s.remove != nil {
+		return s.remove(path)
+	}
+	return os.Remove(path)
 }
 
 type grabberStub struct {
@@ -57,6 +58,7 @@ func createTemper(t *testing.T) temperStub {
 		create: func(_ context.Context, _, pattern string) (*os.File, error) {
 			return os.CreateTemp(t.TempDir(), pattern)
 		},
+		remove: os.Remove,
 	}
 }
 
@@ -64,8 +66,7 @@ func TestDoReturnsTOC(t *testing.T) {
 	want := entity.Toc{"* [Title](#title)"}
 	uc := New(
 		config.Config{},
-		getterStub{body: []byte(`{"payload":{}}`), contentType: "application/json"},
-		writerStub{},
+		getterStub{body: []byte(`{"payload":{}}`), contentType: "application/json; charset=utf-8"},
 		createTemper(t),
 		grabberStub{toc: &want},
 		loggerStub{},
@@ -85,7 +86,6 @@ func TestDoPropagatesDownloadError(t *testing.T) {
 	uc := New(
 		config.Config{},
 		getterStub{err: dependencyErr},
-		writerStub{},
 		createTemper(t),
 		grabberStub{},
 		loggerStub{},
@@ -105,8 +105,7 @@ func TestDoPropagatesGrabberError(t *testing.T) {
 	dependencyErr := errors.New("grab failed")
 	uc := New(
 		config.Config{},
-		getterStub{body: []byte(`{"payload":{}}`)},
-		writerStub{},
+		getterStub{body: []byte(`{"payload":{}}`), contentType: "application/json"},
 		createTemper(t),
 		grabberStub{err: dependencyErr},
 		loggerStub{},
@@ -118,44 +117,119 @@ func TestDoPropagatesGrabberError(t *testing.T) {
 	}
 }
 
-func TestDoPropagatesDebugFileErrors(t *testing.T) {
+func TestDoPropagatesDebugFileCreateError(t *testing.T) {
 	dependencyErr := errors.New("debug file failed")
-	tests := []struct {
-		name   string
-		temper temperStub
-		writer writerStub
-	}{
-		{
-			name: "create",
-			temper: temperStub{
-				create: func(context.Context, string, string) (*os.File, error) {
-					return nil, dependencyErr
-				},
+	uc := New(
+		config.Config{Debug: true},
+		getterStub{body: []byte(`{"payload":{}}`), contentType: "application/json"},
+		temperStub{
+			create: func(context.Context, string, string) (*os.File, error) {
+				return nil, dependencyErr
 			},
 		},
-		{
-			name:   "write",
-			temper: createTemper(t),
-			writer: writerStub{err: dependencyErr},
-		},
+		grabberStub{},
+		loggerStub{},
+	)
+
+	_, err := uc.Do(context.Background(), "https://github.com/example/repo/blob/main/README.md")
+	if !errors.Is(err, dependencyErr) {
+		t.Fatalf("got error %v, want debug file error", err)
 	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			uc := New(
-				config.Config{Debug: true},
-				getterStub{body: []byte(`{"payload":{}}`)},
-				tt.writer,
-				tt.temper,
-				grabberStub{},
-				loggerStub{},
-			)
+func TestDoCleansUpAfterDebugFileWriteError(t *testing.T) {
+	tempPath := filepath.Join(t.TempDir(), "debug.json")
+	if err := os.WriteFile(tempPath, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	uc := New(
+		config.Config{Debug: true},
+		getterStub{body: []byte(`{"payload":{}}`), contentType: "application/json"},
+		temperStub{
+			create: func(context.Context, string, string) (*os.File, error) {
+				return os.Open(tempPath)
+			},
+			remove: os.Remove,
+		},
+		grabberStub{},
+		loggerStub{},
+	)
 
-			_, err := uc.Do(context.Background(), "https://github.com/example/repo/blob/main/README.md")
-			if !errors.Is(err, dependencyErr) {
-				t.Fatalf("got error %v, want debug file error", err)
-			}
-		})
+	_, err := uc.Do(context.Background(), "https://github.com/example/repo/blob/main/README.md")
+	if err == nil {
+		t.Fatal("expected a debug file write error")
+	}
+	if _, statErr := os.Stat(tempPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("failed debug artifact still exists: %v", statErr)
+	}
+}
+
+func TestDoWritesSingleDebugArtifact(t *testing.T) {
+	tempDir := t.TempDir()
+	body := []byte(`{"payload":{"blob":{}}}`)
+	empty := entity.Toc{}
+	uc := New(
+		config.Config{Debug: true},
+		getterStub{body: body, contentType: "application/json"},
+		temperStub{
+			create: func(_ context.Context, _, pattern string) (*os.File, error) {
+				return os.CreateTemp(tempDir, pattern)
+			},
+			remove: os.Remove,
+		},
+		grabberStub{toc: &empty},
+		loggerStub{},
+	)
+
+	if _, err := uc.Do(context.Background(), "https://github.com/example/repo/blob/main/README.md"); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d debug files, want 1", len(entries))
+	}
+	if !strings.HasSuffix(entries[0].Name(), ".debug.json") {
+		t.Errorf("debug artifact %q does not have the expected suffix", entries[0].Name())
+	}
+	got, err := os.ReadFile(filepath.Join(tempDir, entries[0].Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("got debug content %q, want %q", got, body)
+	}
+}
+
+func TestDoRejectsUnexpectedContentType(t *testing.T) {
+	uc := New(
+		config.Config{},
+		getterStub{body: []byte(`{"payload":{}}`), contentType: "text/html"},
+		createTemper(t),
+		grabberStub{},
+		loggerStub{},
+	)
+
+	_, err := uc.Do(context.Background(), "https://github.com/example/repo/blob/main/README.md")
+	if err == nil {
+		t.Fatal("expected an error for an unexpected content type")
+	}
+}
+
+func TestDoRejectsMalformedContentType(t *testing.T) {
+	uc := New(
+		config.Config{},
+		getterStub{body: []byte(`{"payload":{}}`), contentType: `application/json; charset="`},
+		createTemper(t),
+		grabberStub{},
+		loggerStub{},
+	)
+
+	_, err := uc.Do(context.Background(), "https://github.com/example/repo/blob/main/README.md")
+	if err == nil {
+		t.Fatal("expected an error for a malformed content type")
 	}
 }
 
@@ -166,7 +240,6 @@ func TestDoReturnsContextCancellation(t *testing.T) {
 	uc := New(
 		config.Config{},
 		getterStub{},
-		writerStub{},
 		createTemper(t),
 		grabberStub{},
 		loggerStub{},

--- a/internal/core/usecase/remotemd/remotemd.go
+++ b/internal/core/usecase/remotemd/remotemd.go
@@ -2,8 +2,10 @@ package remotemd
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
+	"io"
+	"mime"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/ports"
@@ -18,50 +20,61 @@ type RemoteMd struct {
 	ucLocalMD *localmd.LocalMd
 	getter    ports.RemoteGetter
 	temper    ports.FileTemper
-	writer    ports.FileWriter
 	log       ports.Logger
 }
 
 func New(cfg config.Config, getter ports.RemoteGetter, localMD *localmd.LocalMd,
-	temper ports.FileTemper, writer ports.FileWriter, log ports.Logger) *RemoteMd {
-	return &RemoteMd{cfg, localMD, getter, temper, writer, log}
+	temper ports.FileTemper, log ports.Logger) *RemoteMd {
+	return &RemoteMd{cfg, localMD, getter, temper, log}
 }
 
-func (r *RemoteMd) download(ctx context.Context, url string) (string, error) {
+func (r *RemoteMd) download(ctx context.Context, url string) (path string, err error) {
 	body, contentType, err := r.getter.Get(ctx, url)
 	if err != nil {
 		return "", fmt.Errorf("get remote Markdown %q: %w", url, err)
 	}
 
-	// if not a plain text - it's an error
-	if strings.Split(contentType, ";")[0] != "text/plain" {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return "", fmt.Errorf("parse content type for remote Markdown %q: %w", url, err)
+	}
+	if mediaType != "text/plain" {
 		r.log.Info("RemoteMD: not a plain text, stop.", "content-type", contentType)
 		return "", fmt.Errorf("get remote Markdown %q: unexpected content type %q", url, contentType)
 	}
 
-	// if remote file's content is a plain text
-	// we need to convert it to html
 	tmpfile, err := r.temper.CreateTemp(ctx, "", "ghtoc-remote-txt-*")
 	if err != nil {
 		r.log.Info("RemoteMD: creating tmp file failed.", "err", err)
 		return "", fmt.Errorf("create temporary file for %q: %w", url, err)
 	}
+	tempPath := tmpfile.Name()
+	path = tempPath
 	defer func() {
-		if err := tmpfile.Close(); err != nil {
-			r.log.Info("RemoteMD: closing file failed", "err", err)
+		if closeErr := tmpfile.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close temporary file for %q: %w", url, closeErr))
+		}
+		if err != nil {
+			if removeErr := r.temper.Remove(tempPath); removeErr != nil {
+				err = errors.Join(err, fmt.Errorf("remove temporary file for %q: %w", url, removeErr))
+			}
+			path = ""
 		}
 	}()
 
-	path := tmpfile.Name()
 	r.log.Info("RemoteMD: save content into tmp file", "path", path)
-	if err = r.writer.Write(ctx, tmpfile.Name(), body); err != nil {
+	written, err := tmpfile.Write(body)
+	if err != nil {
 		r.log.Info("RemoteMD: writing file failed.", "err", err)
 		return "", fmt.Errorf("write temporary file for %q: %w", url, err)
+	}
+	if written != len(body) {
+		return "", fmt.Errorf("write temporary file for %q: %w", url, io.ErrShortWrite)
 	}
 	return path, nil
 }
 
-func (r *RemoteMd) Do(ctx context.Context, url string) (entity.Toc, error) {
+func (r *RemoteMd) Do(ctx context.Context, url string) (toc entity.Toc, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("process remote Markdown %q: %w", url, err)
 	}
@@ -71,7 +84,13 @@ func (r *RemoteMd) Do(ctx context.Context, url string) (entity.Toc, error) {
 		r.log.Info("RemoteMD: download fail", "err", err)
 		return nil, err
 	}
-	toc, err := r.ucLocalMD.Do(ctx, filename)
+	defer func() {
+		if removeErr := r.temper.Remove(filename); removeErr != nil {
+			err = errors.Join(err, fmt.Errorf("remove temporary file for remote Markdown %q: %w", url, removeErr))
+		}
+	}()
+
+	toc, err = r.ucLocalMD.Do(ctx, filename)
 	if err != nil {
 		return nil, fmt.Errorf("process remote Markdown %q: %w", url, err)
 	}

--- a/internal/core/usecase/remotemd/remotemd_test.go
+++ b/internal/core/usecase/remotemd/remotemd_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -25,10 +26,18 @@ func (s getterStub) Get(context.Context, string) ([]byte, string, error) {
 
 type temperStub struct {
 	create func(context.Context, string, string) (*os.File, error)
+	remove func(string) error
 }
 
 func (s temperStub) CreateTemp(ctx context.Context, dir, pattern string) (*os.File, error) {
 	return s.create(ctx, dir, pattern)
+}
+
+func (s temperStub) Remove(path string) error {
+	if s.remove != nil {
+		return s.remove(path)
+	}
+	return os.Remove(path)
 }
 
 type writerStub struct {
@@ -74,7 +83,24 @@ func createTemper(t *testing.T) temperStub {
 		create: func(_ context.Context, _, pattern string) (*os.File, error) {
 			return os.CreateTemp(t.TempDir(), pattern)
 		},
+		remove: os.Remove,
 	}
+}
+
+func createTrackingTemper(t *testing.T) (temperStub, *string) {
+	t.Helper()
+	var path string
+	tempDir := t.TempDir()
+	return temperStub{
+		create: func(_ context.Context, _, pattern string) (*os.File, error) {
+			file, err := os.CreateTemp(tempDir, pattern)
+			if err == nil {
+				path = file.Name()
+			}
+			return file, err
+		},
+		remove: os.Remove,
+	}, &path
 }
 
 func newUseCase(
@@ -94,15 +120,16 @@ func newUseCase(
 		grabber,
 		loggerStub{},
 	)
-	return New(config.Config{}, getter, local, temper, writer, loggerStub{})
+	return New(config.Config{}, getter, local, temper, loggerStub{})
 }
 
 func TestDoReturnsTOC(t *testing.T) {
 	want := entity.Toc{"* [Title](#title)"}
+	temper, tempPath := createTrackingTemper(t)
 	uc := newUseCase(
 		t,
-		getterStub{body: []byte("# Title"), contentType: "text/plain"},
-		createTemper(t),
+		getterStub{body: []byte("# Title"), contentType: "text/plain; charset=utf-8"},
+		temper,
 		writerStub{},
 		converterStub{},
 		grabberStub{toc: &want},
@@ -114,6 +141,9 @@ func TestDoReturnsTOC(t *testing.T) {
 	}
 	if !slices.Equal(got, want) {
 		t.Errorf("got TOC %v, want %v", got, want)
+	}
+	if _, err := os.Stat(*tempPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("temporary file still exists after success: %v", err)
 	}
 }
 
@@ -159,29 +189,42 @@ func TestDoPropagatesTemporaryFileError(t *testing.T) {
 	}
 }
 
-func TestDoPropagatesWriterError(t *testing.T) {
-	dependencyErr := errors.New("write failed")
+func TestDoCleansUpAfterTemporaryFileWriteError(t *testing.T) {
+	tempPath := filepath.Join(t.TempDir(), "remote.md")
+	if err := os.WriteFile(tempPath, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	temper := temperStub{
+		create: func(context.Context, string, string) (*os.File, error) {
+			return os.Open(tempPath)
+		},
+		remove: os.Remove,
+	}
 	uc := newUseCase(
 		t,
 		getterStub{body: []byte("# Title"), contentType: "text/plain"},
-		createTemper(t),
-		writerStub{err: dependencyErr},
+		temper,
+		writerStub{},
 		converterStub{},
 		grabberStub{},
 	)
 
 	_, err := uc.Do(context.Background(), "https://example.com/README.md")
-	if !errors.Is(err, dependencyErr) {
-		t.Fatalf("got error %v, want writer error", err)
+	if err == nil {
+		t.Fatal("expected a temporary file write error")
+	}
+	if _, statErr := os.Stat(tempPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("temporary file still exists after write error: %v", statErr)
 	}
 }
 
 func TestDoKeepsRemotePathForLocalProcessingError(t *testing.T) {
 	dependencyErr := errors.New("convert failed")
+	temper, tempPath := createTrackingTemper(t)
 	uc := newUseCase(
 		t,
 		getterStub{body: []byte("# Title"), contentType: "text/plain"},
-		createTemper(t),
+		temper,
 		writerStub{},
 		converterStub{err: dependencyErr},
 		grabberStub{},
@@ -194,6 +237,9 @@ func TestDoKeepsRemotePathForLocalProcessingError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), documentURL) {
 		t.Errorf("error %q does not contain the original document URL", err)
+	}
+	if _, statErr := os.Stat(*tempPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("temporary file still exists after processing error: %v", statErr)
 	}
 }
 
@@ -210,5 +256,43 @@ func TestDoRejectsUnexpectedContentType(t *testing.T) {
 	_, err := uc.Do(context.Background(), "https://example.com/README.md")
 	if err == nil {
 		t.Fatal("expected an error for an unexpected content type")
+	}
+}
+
+func TestDoRejectsMalformedContentType(t *testing.T) {
+	uc := newUseCase(
+		t,
+		getterStub{body: []byte("# Title"), contentType: `text/plain; charset="`},
+		createTemper(t),
+		writerStub{},
+		converterStub{},
+		grabberStub{},
+	)
+
+	_, err := uc.Do(context.Background(), "https://example.com/README.md")
+	if err == nil {
+		t.Fatal("expected an error for a malformed content type")
+	}
+}
+
+func TestDoReturnsTemporaryFileRemovalError(t *testing.T) {
+	removeErr := errors.New("remove failed")
+	temper := createTemper(t)
+	temper.remove = func(string) error {
+		return removeErr
+	}
+	want := entity.Toc{"* [Title](#title)"}
+	uc := newUseCase(
+		t,
+		getterStub{body: []byte("# Title"), contentType: "text/plain"},
+		temper,
+		writerStub{},
+		converterStub{},
+		grabberStub{toc: &want},
+	)
+
+	_, err := uc.Do(context.Background(), "https://example.com/README.md")
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("got error %v, want removal error", err)
 	}
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -13,10 +12,48 @@ import (
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
 
+const (
+	maxResponseBodyBytes int64 = 10 << 20
+	maxErrorBodyBytes    int64 = 4 << 10
+)
+
+type HTTPStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("unexpected HTTP status %d", e.StatusCode)
+	}
+	return fmt.Sprintf("unexpected HTTP status %d: %s", e.StatusCode, e.Body)
+}
+
+type ResponseBodyTooLargeError struct {
+	Limit int64
+}
+
+func (e *ResponseBodyTooLargeError) Error() string {
+	return fmt.Sprintf("HTTP response body exceeds %d bytes", e.Limit)
+}
+
+func readLimitedBody(body io.Reader, limit int64) ([]byte, bool, error) {
+	data, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) > limit {
+		return data[:limit], true, nil
+	}
+	return data, false, nil
+}
+
 // doHTTPReq executes a particular http request
-func doHTTPReq(req *http.Request) ([]byte, string, error) {
+func doHTTPReq(client *http.Client, req *http.Request) ([]byte, string, error) {
+	if client == nil {
+		return []byte{}, "", errors.New("HTTP client is nil")
+	}
 	req.Header.Set("User-Agent", version.UserAgent)
-	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return []byte{}, "", err
@@ -25,39 +62,55 @@ func doHTTPReq(req *http.Request) ([]byte, string, error) {
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	body, err := io.ReadAll(resp.Body)
+
+	contentType := resp.Header.Get("Content-Type")
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _, err := readLimitedBody(resp.Body, maxErrorBodyBytes)
+		if err != nil {
+			return []byte{}, contentType, fmt.Errorf("read HTTP error response: %w", err)
+		}
+		return []byte{}, contentType, &HTTPStatusError{
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(strings.ToValidUTF8(string(body), "\uFFFD")),
+		}
+	}
+
+	if resp.ContentLength > maxResponseBodyBytes {
+		return []byte{}, contentType, &ResponseBodyTooLargeError{Limit: maxResponseBodyBytes}
+	}
+
+	body, tooLarge, err := readLimitedBody(resp.Body, maxResponseBodyBytes)
 	if err != nil {
-		return []byte{}, "", err
+		return []byte{}, contentType, err
+	}
+	if tooLarge {
+		return []byte{}, contentType, &ResponseBodyTooLargeError{Limit: maxResponseBodyBytes}
 	}
 
-	if resp.StatusCode == http.StatusForbidden {
-		return []byte{}, resp.Header.Get("Content-type"), errors.New(string(body))
-	}
-
-	return body, resp.Header.Get("Content-type"), nil
+	return body, contentType, nil
 }
 
 // HttpGet executes HTTP GET request.
-func HttpGet(ctx context.Context, urlPath string) ([]byte, string, error) {
+func HttpGet(ctx context.Context, client *http.Client, urlPath string) ([]byte, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlPath, nil)
 	if err != nil {
 		return []byte{}, "", err
 	}
-	return doHTTPReq(req)
+	return doHTTPReq(client, req)
 }
 
-func HttpGetJson(ctx context.Context, urlPath string) ([]byte, string, error) {
+func HttpGetJson(ctx context.Context, client *http.Client, urlPath string) ([]byte, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlPath, nil)
 	if err != nil {
 		return []byte{}, "", err
 	}
 	req.Header.Set("Content-type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	return doHTTPReq(req)
+	return doHTTPReq(client, req)
 }
 
 // HttpPost executes HTTP POST with file content.
-func HttpPost(ctx context.Context, url, path, token string) (string, error) {
+func HttpPost(ctx context.Context, client *http.Client, url, path, token string) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return "", err
@@ -66,23 +119,22 @@ func HttpPost(ctx context.Context, url, path, token string) (string, error) {
 		_ = file.Close()
 	}()
 
-	body := &bytes.Buffer{}
-	_, err = io.Copy(body, file)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, file)
 	if err != nil {
 		return "", err
 	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	fileInfo, err := file.Stat()
 	if err != nil {
 		return "", err
 	}
+	req.ContentLength = fileInfo.Size()
 
 	if token != "" {
 		req.Header.Add("Authorization", "token "+token)
 	}
 	req.Header.Set("Content-Type", "text/plain;charset=utf-8")
 
-	resp, _, err := doHTTPReq(req)
+	resp, _, err := doHTTPReq(client, req)
 	return string(resp), err
 }
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -5,15 +5,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
+
+func testHTTPClient() *http.Client {
+	return &http.Client{Timeout: time.Second}
+}
 
 func TestHttpGet(t *testing.T) {
 	expected := "dummy data"
@@ -23,6 +30,7 @@ func TestHttpGet(t *testing.T) {
 			t.Errorf("User-agent should be=%s, got=%s\n", version.UserAgent, ua)
 		}
 
+		w.WriteHeader(http.StatusCreated)
 		_, err := fmt.Fprint(w, expected)
 		if err != nil {
 			println(err)
@@ -30,7 +38,7 @@ func TestHttpGet(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	body, _, err := HttpGet(context.Background(), srv.URL)
+	body, _, err := HttpGet(context.Background(), testHTTPClient(), srv.URL)
 	got := string(body)
 
 	if err != nil {
@@ -65,7 +73,7 @@ func TestHttpGetJson(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	body, _, err := HttpGetJson(context.Background(), srv.URL)
+	body, _, err := HttpGetJson(context.Background(), testHTTPClient(), srv.URL)
 	got := string(body)
 
 	if err != nil {
@@ -76,40 +84,69 @@ func TestHttpGetJson(t *testing.T) {
 	}
 }
 
-func TestHttpGetForbidden(t *testing.T) {
-	txt := "please, do not try"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		_, err := fmt.Fprint(w, txt)
-		if err != nil {
-			println(err)
-		}
-	}))
-	defer srv.Close()
+func TestHTTPStatusError(t *testing.T) {
+	for _, statusCode := range []int{http.StatusBadRequest, http.StatusInternalServerError} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			const responseBody = "request failed"
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(statusCode)
+				_, _ = fmt.Fprint(w, responseBody)
+			}))
+			defer srv.Close()
 
-	_, _, err := HttpGet(context.Background(), srv.URL)
-	if err == nil {
-		t.Error("Should not not be nil")
+			_, _, err := HttpGet(context.Background(), testHTTPClient(), srv.URL)
+			var statusErr *HTTPStatusError
+			if !errors.As(err, &statusErr) {
+				t.Fatalf("got error %v, want HTTPStatusError", err)
+			}
+			if statusErr.StatusCode != statusCode {
+				t.Errorf("got status %d, want %d", statusErr.StatusCode, statusCode)
+			}
+			if statusErr.Body != responseBody {
+				t.Errorf("got body fragment %q, want %q", statusErr.Body, responseBody)
+			}
+		})
 	}
 }
 
-func createTmp(content string) (string, error) {
-	tmpFile, err := os.CreateTemp("", "example.*.txt")
-	if err != nil {
-		log.Fatal(err)
-	}
+func TestHTTPStatusErrorLimitsBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = fmt.Fprint(w, strings.Repeat("x", int(maxErrorBodyBytes)+100))
+	}))
+	defer srv.Close()
 
-	if _, err := tmpFile.Write([]byte(content)); err != nil {
-		if err := tmpFile.Close(); err != nil {
-			return "", err
-		}
-		log.Fatal(err)
+	_, _, err := HttpGet(context.Background(), testHTTPClient(), srv.URL)
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("got error %v, want HTTPStatusError", err)
 	}
-	if err := tmpFile.Close(); err != nil {
-		log.Fatal(err)
+	if got := int64(len(statusErr.Body)); got > maxErrorBodyBytes {
+		t.Errorf("got error body length %d, limit is %d", got, maxErrorBodyBytes)
 	}
+}
 
-	return tmpFile.Name(), nil
+func TestHTTPResponseBodyLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", strconv.FormatInt(maxResponseBodyBytes+1, 10))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, _, err := HttpGet(context.Background(), testHTTPClient(), srv.URL)
+	var tooLargeErr *ResponseBodyTooLargeError
+	if !errors.As(err, &tooLargeErr) {
+		t.Fatalf("got error %v, want ResponseBodyTooLargeError", err)
+	}
+}
+
+func createTmp(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "request.md")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestHttpPost(t *testing.T) {
@@ -126,15 +163,9 @@ func TestHttpPost(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	fileName, err := createTmp("#some title")
-	if err != nil {
-		t.Error("Should not be err", err)
-	}
-	defer func() {
-		_ = os.Remove(fileName)
-	}()
+	fileName := createTmp(t, "#some title")
 
-	_, err = HttpPost(context.Background(), srv.URL, fileName, token)
+	_, err := HttpPost(context.Background(), testHTTPClient(), srv.URL, fileName, token)
 	if err != nil {
 		t.Error("Should not be err", err)
 	}
@@ -152,18 +183,12 @@ func TestHttpPostCancelsInFlightRequest(t *testing.T) {
 		srv.Close()
 	}()
 
-	fileName, err := createTmp("# some title")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = os.Remove(fileName)
-	}()
+	fileName := createTmp(t, "# some title")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := HttpPost(ctx, srv.URL, fileName, "")
+		_, err := HttpPost(ctx, testHTTPClient(), srv.URL, fileName, "")
 		done <- err
 	}()
 
@@ -184,6 +209,43 @@ func TestHttpPostCancelsInFlightRequest(t *testing.T) {
 	}
 }
 
+func TestHTTPClientTimeout(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	}))
+	defer func() {
+		close(release)
+		srv.Close()
+	}()
+
+	client := &http.Client{Timeout: 50 * time.Millisecond}
+	_, _, err := HttpGet(context.Background(), client, srv.URL)
+	if err == nil {
+		t.Fatal("expected an HTTP client timeout")
+	}
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("got error %v, want a network timeout", err)
+	}
+}
+
+func TestHTTPHelpersRejectMalformedURL(t *testing.T) {
+	const malformedURL = "://bad-url"
+	client := testHTTPClient()
+	ctx := context.Background()
+
+	if _, _, err := HttpGet(ctx, client, malformedURL); err == nil {
+		t.Error("HttpGet accepted a malformed URL")
+	}
+	if _, _, err := HttpGetJson(ctx, client, malformedURL); err == nil {
+		t.Error("HttpGetJson accepted a malformed URL")
+	}
+	if _, err := HttpPost(ctx, client, malformedURL, createTmp(t, "body"), ""); err == nil {
+		t.Error("HttpPost accepted a malformed URL")
+	}
+}
+
 // Cover the changes of ioutil.ReadAll to io.ReadAll in doHTTPReq.
 func Test_doHTTPReq_issue35(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -198,7 +260,7 @@ func Test_doHTTPReq_issue35(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resBody, resHeader, err := doHTTPReq(req)
+	resBody, resHeader, err := doHTTPReq(testHTTPClient(), req)
 
 	// Require no error
 	if err != nil {


### PR DESCRIPTION
## Summary

- inject one HTTP client with a finite timeout into remote GET and POST adapters
- accept only 2xx responses and return typed status errors with bounded body fragments
- limit successful response bodies and validate response media types
- stream POST bodies from files instead of buffering them in memory
- close and remove remote Markdown and stdin temporary files on success and failure
- write debug JSON directly to a single retained artifact

## Checks

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `GOTOOLCHAIN=go1.21.13 go test ./...`
- `go vet ./...`
- `golangci-lint run`
- `go mod tidy -diff`