### PR TITLE
fix(controller): preserve concurrent output order

### DIFF
--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,10 +75,194 @@ func TestProcessFilesAcceptsEmptyTOC(t *testing.T) {
 	}
 }
 
-func TestProcessFilesStopsWaitingAfterContextCancellation(t *testing.T) {
-	started := make(chan struct{})
+func TestProcessFilesPreservesInputOrder(t *testing.T) {
+	files := []string{"first.md", "second.md", "third.md"}
+	started := make(chan string, len(files))
+	completed := make(chan string, len(files))
+	releases := map[string]chan struct{}{
+		"first.md":  make(chan struct{}),
+		"second.md": make(chan struct{}),
+		"third.md":  make(chan struct{}),
+	}
+	uc := useCaseFunc(func(_ context.Context, path string) (entity.Toc, error) {
+		started <- path
+		<-releases[path]
+		completed <- path
+		return entity.Toc{path}, nil
+	})
+	ctl := newTestController(Config{}, uc)
+
+	var stdout bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- ctl.ProcessFiles(context.Background(), &stdout, files...)
+	}()
+
+	for range files {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("not all use cases started")
+		}
+	}
+	for _, path := range []string{"third.md", "second.md", "first.md"} {
+		close(releases[path])
+		select {
+		case got := <-completed:
+			if got != path {
+				t.Fatalf("got completed path %q, want %q", got, path)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("use case %q did not complete", path)
+		}
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("controller did not finish")
+	}
+
+	if got, want := stdout.String(), "first.md\n\nsecond.md\n\nthird.md\n\n"; got != want {
+		t.Errorf("got output %q, want %q", got, want)
+	}
+}
+
+func TestProcessFilesSerialAndParallelOutputsMatch(t *testing.T) {
+	files := []string{"first.md", "second.md", "third.md"}
+	uc := useCaseFunc(func(_ context.Context, path string) (entity.Toc, error) {
+		return entity.Toc{path}, nil
+	})
+	run := func(serial bool) string {
+		t.Helper()
+		ctl := newTestController(Config{Serial: serial}, uc)
+		var stdout bytes.Buffer
+		if err := ctl.ProcessFiles(context.Background(), &stdout, files...); err != nil {
+			t.Fatal(err)
+		}
+		return stdout.String()
+	}
+
+	serialOutput := run(true)
+	parallelOutput := run(false)
+	if serialOutput != parallelOutput {
+		t.Errorf("serial output %q does not match parallel output %q", serialOutput, parallelOutput)
+	}
+}
+
+func TestProcessFilesLimitsParallelism(t *testing.T) {
+	files := make([]string, maxParallelFiles+4)
+	for i := range files {
+		files[i] = fmt.Sprintf("file-%d.md", i)
+	}
+
+	started := make(chan struct{}, len(files))
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWorkers := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	t.Cleanup(releaseWorkers)
+
+	var active atomic.Int32
+	var peak atomic.Int32
 	uc := useCaseFunc(func(ctx context.Context, _ string) (entity.Toc, error) {
-		close(started)
+		current := active.Add(1)
+		defer active.Add(-1)
+		for observed := peak.Load(); current > observed; observed = peak.Load() {
+			if peak.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		select {
+		case <-release:
+			return entity.Toc{}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	})
+	ctl := newTestController(Config{}, uc)
+	done := make(chan error, 1)
+	go func() {
+		done <- ctl.ProcessFiles(context.Background(), io.Discard, files...)
+	}()
+
+	for i := 0; i < maxParallelFiles; i++ {
+		select {
+		case <-started:
+		case err := <-done:
+			t.Fatalf("controller returned before workers were released: %v", err)
+		case <-time.After(time.Second):
+			t.Fatal("parallel workers did not start")
+		}
+	}
+	select {
+	case <-started:
+		t.Fatalf("more than %d use cases started concurrently", maxParallelFiles)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseWorkers()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("controller did not finish after workers were released")
+	}
+	if got := peak.Load(); got != maxParallelFiles {
+		t.Errorf("got peak parallelism %d, want %d", got, maxParallelFiles)
+	}
+}
+
+func TestProcessFilesCompletesAllJobsAfterErrors(t *testing.T) {
+	files := make([]string, maxParallelFiles*2)
+	for i := range files {
+		files[i] = fmt.Sprintf("file-%d.md", i)
+	}
+
+	processingErr := errors.New("processing failed")
+	var completed atomic.Int32
+	uc := useCaseFunc(func(_ context.Context, path string) (entity.Toc, error) {
+		completed.Add(1)
+		if path == "file-0.md" {
+			return nil, processingErr
+		}
+		return entity.Toc{path}, nil
+	})
+	ctl := newTestController(Config{}, uc)
+	done := make(chan error, 1)
+	go func() {
+		done <- ctl.ProcessFiles(context.Background(), io.Discard, files...)
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, processingErr) {
+			t.Fatalf("got error %v, want processing error", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("controller deadlocked after a use case error")
+	}
+	if got, want := completed.Load(), int32(len(files)); got != want {
+		t.Errorf("completed %d jobs, want %d", got, want)
+	}
+}
+
+func TestProcessFilesStopsWaitingAfterContextCancellation(t *testing.T) {
+	files := make([]string, maxParallelFiles+4)
+	for i := range files {
+		files[i] = fmt.Sprintf("slow-%d.md", i)
+	}
+
+	started := make(chan struct{}, maxParallelFiles)
+	uc := useCaseFunc(func(ctx context.Context, _ string) (entity.Toc, error) {
+		started <- struct{}{}
 		<-ctx.Done()
 		return nil, ctx.Err()
 	})
@@ -85,13 +271,15 @@ func TestProcessFilesStopsWaitingAfterContextCancellation(t *testing.T) {
 	done := make(chan error, 1)
 
 	go func() {
-		done <- ctl.ProcessFiles(ctx, io.Discard, "slow.md")
+		done <- ctl.ProcessFiles(ctx, io.Discard, files...)
 	}()
 
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("use case did not start")
+	for i := 0; i < maxParallelFiles; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("parallel workers did not start")
+		}
 	}
 	cancel()
 
@@ -100,7 +288,7 @@ func TestProcessFilesStopsWaitingAfterContextCancellation(t *testing.T) {
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("got error %v, want context cancellation", err)
 		}
-		if !strings.Contains(err.Error(), "slow.md") {
+		if !strings.Contains(err.Error(), "slow-0.md") {
 			t.Errorf("error %q does not contain the document path", err)
 		}
 	case <-time.After(time.Second):

--- a/internal/controller/file.go
+++ b/internal/controller/file.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 )
@@ -26,54 +27,50 @@ func (ctl *Controller) getUseCase(file string) useCase {
 }
 
 type processResult struct {
-	path string
-	toc  entity.Toc
-	err  error
+	index int
+	path  string
+	toc   entity.Toc
+	err   error
 }
+
+type processJob struct {
+	index int
+	path  string
+}
+
+const maxParallelFiles = 8
 
 func (ctl *Controller) ProcessFiles(ctx context.Context, stdout io.Writer, files ...string) error {
 	ctl.log.Info("Controller.ProcessFiles: start", "files", files)
-	cnt := len(files)
+	jobs := make(chan processJob, len(files))
+	resultCh := make(chan processResult, len(files))
+	for index, path := range files {
+		jobs <- processJob{index: index, path: path}
+	}
+	close(jobs)
 
-	ch := make(chan processResult, cnt)
-	for _, file := range files {
-		ctl.log.Info("Controller.ProcessFiles: processing", "file", file)
-		uc := ctl.getUseCase(file)
-		if uc == nil {
-			ch <- processResult{
-				path: file,
-				err:  fmt.Errorf("process %q: select use case: use case is nil", file),
-			}
-			continue
-		}
-
-		process := func(ctx context.Context, uc useCase, path string) processResult {
-			if err := ctx.Err(); err != nil {
-				return processResult{
-					path: path,
-					err:  fmt.Errorf("process %q: %w", path, err),
-				}
-			}
-
-			toc, err := uc.Do(ctx, path)
-			if err != nil {
-				err = fmt.Errorf("process %q: %w", path, err)
-			}
-			return processResult{path: path, toc: toc, err: err}
-		}
-
-		if ctl.cfg.Serial {
-			ch <- process(ctx, uc, file)
-		} else {
-			go func(ctx context.Context, uc useCase, path string) {
-				ch <- process(ctx, uc, path)
-			}(ctx, uc, file)
-		}
+	workerCount := min(len(files), maxParallelFiles)
+	if ctl.cfg.Serial {
+		workerCount = min(len(files), 1)
+	}
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			defer workers.Done()
+			ctl.processFilesWorker(ctx, jobs, resultCh)
+		}()
 	}
 
+	results := make([]processResult, len(files))
+	for range files {
+		result := <-resultCh
+		results[result.index] = result
+	}
+	workers.Wait()
+
 	var errs []error
-	for i := 0; i < cnt; i++ {
-		result := <-ch
+	for _, result := range results {
 		if result.err != nil {
 			errs = append(errs, result.err)
 			continue
@@ -83,4 +80,35 @@ func (ctl *Controller) ProcessFiles(ctx context.Context, stdout io.Writer, files
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (ctl *Controller) processFilesWorker(
+	ctx context.Context,
+	jobs <-chan processJob,
+	results chan<- processResult,
+) {
+	for job := range jobs {
+		results <- ctl.processFile(ctx, job)
+	}
+}
+
+func (ctl *Controller) processFile(ctx context.Context, job processJob) processResult {
+	result := processResult{index: job.index, path: job.path}
+	if err := ctx.Err(); err != nil {
+		result.err = fmt.Errorf("process %q: %w", job.path, err)
+		return result
+	}
+
+	ctl.log.Info("Controller.ProcessFiles: processing", "file", job.path)
+	uc := ctl.getUseCase(job.path)
+	if uc == nil {
+		result.err = fmt.Errorf("process %q: select use case: use case is nil", job.path)
+		return result
+	}
+
+	result.toc, result.err = uc.Do(ctx, job.path)
+	if result.err != nil {
+		result.err = fmt.Errorf("process %q: %w", job.path, result.err)
+	}
+	return result
 }


### PR DESCRIPTION
## Summary

- process files through a shared worker pool in serial and parallel modes
- cap parallel processing at eight concurrent files
- collect indexed results and print TOCs in CLI argument order
- finish queued jobs safely after errors or context cancellation

## Verification

- env GOTOOLCHAIN=go1.21.13 go test ./...
- env GOTOOLCHAIN=go1.26.5 go test -race ./...
- go test -count=50 ./internal/controller
- go vet ./...
- golangci-lint run ./...
- go mod tidy -diff
- go mod verify