### PR TITLE
fix(e2e): run complete CLI package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ EXEC=gh-md-toc
 CMD_SRC=cmd/${EXEC}/main.go
 BUILD_DIR=build
 E2E_DIR=e2e-tests
-E2E_RUN=go run cmd/gh-md-toc/main.go ./README.md
-E2E_RUN_RHTML=go run cmd/gh-md-toc/main.go https://github.com/ekalinin/github-markdown-toc.go/blob/master/README.md
-E2E_RUN_RMD=go run cmd/gh-md-toc/main.go https://raw.githubusercontent.com/ekalinin/github-markdown-toc.go/master/README.md
+E2E_RUN=go run ./cmd/${EXEC} ./README.md
+E2E_RUN_RHTML=go run ./cmd/${EXEC} https://github.com/ekalinin/github-markdown-toc.go/blob/master/README.md
+E2E_RUN_RMD=go run ./cmd/${EXEC} https://raw.githubusercontent.com/ekalinin/github-markdown-toc.go/master/README.md
 bold := $(shell tput bold)
 clear := $(shell tput sgr0)
 


### PR DESCRIPTION
## Summary

Run the complete `cmd/gh-md-toc` package in the Makefile e2e commands instead of compiling only `main.go`.

## Regression source

The regression was introduced in [PR #60](https://github.com/ekalinin/github-markdown-toc.go/pull/60).

That PR moved CLI configuration and `parseConfig` from `main.go` into a separate `config.go` file. The Makefile continued to execute:

```text
go run cmd/gh-md-toc/main.go
```

Running a specific Go file compiles only that file, so `config.go` was excluded and every e2e command failed with:

```text
cmd/gh-md-toc/main.go:27:14: undefined: parseConfig
```

The issue was discovered while validating [PR #64](https://github.com/ekalinin/github-markdown-toc.go/pull/64) and is intentionally fixed in this separate PR.

## Fix

Update all three e2e command variables to run the complete CLI package:

```text
go run ./cmd/${EXEC}
```

This includes every Go file in `cmd/gh-md-toc`, including `main.go` and `config.go`.

The change covers:

- local Markdown e2e scenarios
- raw remote Markdown e2e scenarios
- GitHub blob URL e2e scenarios

## Verification

`make e2e` passes all nine scenarios:

- local Markdown with default options
- local Markdown with depth and escaping options
- local Markdown with custom indentation
- raw remote Markdown with default options
- raw remote Markdown with depth and escaping options
- raw remote Markdown with custom indentation
- GitHub blob URL with default options
- GitHub blob URL with depth and escaping options
- GitHub blob URL with custom indentation

All generated results match the existing golden files.
