### PR TITLE
chore(release): migrate GoReleaser configuration

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -2,14 +2,14 @@ name: goreleaser
 
 on:
   push:
-    branches:
-      - "!*"
     tags:
       - "v*.*.*"
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,11 +21,19 @@ jobs:
         with:
           go-version: "1.26.5"
 
+      - name: Verify tag matches the app version
+        run: |
+          version=$(grep -E '^[[:space:]]*Version' internal/version/version.go | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ "v$version" != "$GITHUB_REF_NAME" ]; then
+            echo "tag $GITHUB_REF_NAME does not match version $version in internal/version/version.go"
+            exit 1
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,9 @@
+version: 2
 project_name: gh-md-toc
 before:
   hooks:
-    # You may remove this if you don't use go modules.
-    - go mod tidy
+    # Verify the module files are tidy without mutating them mid-release.
+    - go mod tidy -diff
 builds:
   - env:
       - CGO_ENABLED=0
@@ -18,7 +19,7 @@ builds:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ E2E_DIR=e2e-tests
 E2E_RUN=go run ./cmd/${EXEC} ./README.md
 E2E_RUN_RHTML=go run ./cmd/${EXEC} https://github.com/ekalinin/github-markdown-toc.go/blob/master/README.md
 E2E_RUN_RMD=go run ./cmd/${EXEC} https://raw.githubusercontent.com/ekalinin/github-markdown-toc.go/master/README.md
+VERSION=$(shell grep "\tVersion" internal/version/version.go | grep -o -E '[0-9]\.[0-9]\.[0-9]{1,2}')
+TAG=v${VERSION}
 bold := $(shell tput bold)
 clear := $(shell tput sgr0)
 
@@ -56,10 +58,20 @@ e2e:
 	${E2E_RUN_RHTML} --hide-header --hide-footer --indent=4 > ${E2E_DIR}/got9.md
 	@diff ${E2E_DIR}/want3.md ${E2E_DIR}/got9.md
 
-release: test
-	@git tag v`grep "\tVersion" internal/version/version.go | grep -o -E '[0-9]\.[0-9]\.[0-9]{1,2}'`
-	@git push --tags origin master
+# Step 2: create the release tag locally. Does not push anything.
+release: test release-local
+	@if git rev-parse -q --verify refs/tags/${TAG} >/dev/null; then \
+		echo "${bold}tag ${TAG} already exists${clear}"; \
+		exit 1; \
+	fi
+	@git tag ${TAG}
+	@echo "${bold}>> tag ${TAG} created, run 'make release-push' to publish${clear}"
 
+# Step 1: validate the release locally. Creates neither tag nor push.
 release-local:
 	@goreleaser check
 	@goreleaser release --snapshot --clean
+
+# Step 3: publish the tag, which triggers the goreleaser workflow.
+release-push:
+	@git push origin ${TAG}


### PR DESCRIPTION
## What changed

### `.goreleaser.yaml`

- Schema `version: 2` (GoReleaser v2 refuses `version: 0` configs).
- `snapshot.name_template` -> `snapshot.version_template` (the old key is deprecated).
- Before-hook `go mod tidy` -> `go mod tidy -diff`. The old hook could rewrite `go.mod`/`go.sum` in the middle of a release; the new one only fails if they are untidy.

### `Makefile`

The old `release` target tagged and pushed in one go, and its push was `git push --tags origin master` - it published every local tag plus the `master` branch. Now the flow is three explicit steps:

| Target | Does |
| --- | --- |
| `make release-local` | validate only: `goreleaser check` + snapshot build |
| `make release` | run tests, validate, create the tag locally - no push |
| `make release-push` | push that one tag, which triggers the release workflow |

`make release` also refuses to run if the tag already exists. Version extraction moved into the `VERSION`/`TAG` variables so the tag name is derived once.

### `.github/workflows/goreleaser.yml`

- Dropped the `branches: - "!*"` filter, leaving the `v*.*.*` tag pattern as the only trigger.
- Added the minimal `permissions: contents: write` the job needs to publish a release.
- Pinned `goreleaser-action` to `~> v2` instead of `latest`.
- New step verifies the pushed tag matches `internal/version/version.go` before anything is built.

## Acceptance criteria

| Check | Result |
| --- | --- |
| `goreleaser check` | valid, no deprecation warnings |
| `goreleaser release --snapshot --clean` | 7 archives (linux amd64/arm64/armv6, darwin amd64/arm64, windows amd64/arm64) + `checksums.txt` |
| `release` target does not push | confirmed, `make release` creates the tag only; `git ls-remote` shows nothing published |
| tag workflow only for `v*.*.*` | confirmed via parsed workflow trigger |
| binary version matches git tag | binary reports `2.0.1` at tag `v2.0.1`; workflow now enforces this |
| working tree clean after release validation | confirmed, only `dist/` is written and it is gitignored |
| `make test` (vet + golangci-lint + unit) | pass, 0 lint issues |
| `make e2e` (live GitHub API) | pass, all 9 diffs clean |

No Go source changed.