### PR TITLE
docs(changelog): add CHANGELOG.md

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,10 @@ checksum:
   name_template: 'checksums.txt'
 snapshot:
   version_template: "{{ .Tag }}-next"
+release:
+  footer: |
+    ---
+    Curated notes for this release are in [CHANGELOG.md](https://github.com/ekalinin/github-markdown-toc.go/blob/master/CHANGELOG.md).
 changelog:
   sort: asc
   filters:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Use the standard `testing` package. Name tests `TestXxx` and prefer table-driven
 
 Use Conventional Commits, for example `fix(http): reject oversized responses` or `refactor(toc): simplify rendering`. Use typed branch prefixes such as `fix/`, `refactor/`, `feat/`, `docs/`, or `chore/`, based on `master`. Keep each PR focused. Explain what changed, why it changed, compatibility impact, and exact validation commands. Link the originating issue or regression PR when applicable. Include CLI output examples when observable formatting changes.
 
+Record user-visible changes in [CHANGELOG.md](CHANGELOG.md) under `[Unreleased]` in the same PR, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Internal refactors that leave CLI behaviour and output unchanged do not need an entry. GoReleaser still generates the per-release commit list on the GitHub release page; `CHANGELOG.md` is the curated history and takes precedence when the two differ in emphasis.
+
 ## Security and configuration
 
 Never log or commit GitHub tokens. Use `GH_TOC_TOKEN` for authentication and `GH_TOC_URL` for an alternate API endpoint. Keep secrets out of tests, fixtures, debug output, and PR descriptions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Planned release: 2.1.0.
+
+The generated table of contents is byte-identical to 2.0.1. Everything below is about
+CLI behaviour, not about the output format.
+
+### Security
+
+- `--debug` no longer prints the GitHub token. Up to and including 2.0.1, a token passed
+  through `--token` or `GH_TOC_TOKEN` was written to the debug output as part of the
+  dumped configuration. **If you ran `gh-md-toc --debug` in CI or any environment with
+  shared logs, rotate that token.** The debug output now only reports whether a token was
+  configured. ([#60](https://github.com/ekalinin/github-markdown-toc.go/pull/60))
+
+### Changed
+
+- The CLI now exits with a non-zero status when a document fails to process. Previously it
+  exited 0 even when the file did not exist or an extractor failed, so failures were
+  invisible to callers. Scripts that relied on the old always-zero status need review.
+  ([#61](https://github.com/ekalinin/github-markdown-toc.go/pull/61))
+- Output order for multiple documents now always matches the order of the CLI arguments.
+  Previously results were printed in completion order and varied between runs.
+  ([#63](https://github.com/ekalinin/github-markdown-toc.go/pull/63))
+- Parallel processing is bounded to 8 documents at a time. `--serial` still processes one
+  at a time and now goes through the same aggregation path as the parallel mode.
+  ([#63](https://github.com/ekalinin/github-markdown-toc.go/pull/63))
+- An unsupported `--re-version` value now fails with an explicit error listing the
+  supported versions, instead of silently producing an empty TOC and exiting 0.
+  ([#60](https://github.com/ekalinin/github-markdown-toc.go/pull/60))
+- `Ctrl-C` and `SIGTERM` now cancel in-flight requests instead of being ignored until the
+  current operation finishes.
+  ([#61](https://github.com/ekalinin/github-markdown-toc.go/pull/61))
+- Error messages name the document that failed and the operation that failed on it.
+  ([#61](https://github.com/ekalinin/github-markdown-toc.go/pull/61))
+- Building from source now requires Go 1.21 or newer, matching the `log/slog` usage that
+  was already in the code. Releases are built with Go 1.26.5.
+  ([#58](https://github.com/ekalinin/github-markdown-toc.go/pull/58))
+
+### Fixed
+
+- `GH_TOC_URL` is honoured again when `--github-url` is not passed. The flag's non-empty
+  default used to shadow the environment variable, so the variable had no effect.
+  ([#60](https://github.com/ekalinin/github-markdown-toc.go/pull/60))
+- Temporary files created for STDIN input and for downloaded remote Markdown are removed
+  on every path, including error paths. Previously a remote run left one file behind.
+  ([#62](https://github.com/ekalinin/github-markdown-toc.go/pull/62))
+- HTTP requests carry a context and a 30 second timeout, so an unresponsive server no
+  longer hangs the CLI indefinitely.
+  ([#62](https://github.com/ekalinin/github-markdown-toc.go/pull/62))
+- Only 2xx responses are treated as success. Other responses produce an error carrying the
+  status code and a truncated response body, instead of being parsed as content.
+  ([#62](https://github.com/ekalinin/github-markdown-toc.go/pull/62))
+- Response bodies are capped at 10 MiB.
+  ([#62](https://github.com/ekalinin/github-markdown-toc.go/pull/62))
+- `Content-Type` is parsed with `mime.ParseMediaType`, so values carrying parameters such
+  as `text/plain; charset=utf-8` are recognised correctly, and an unexpected media type is
+  reported as an error.
+  ([#62](https://github.com/ekalinin/github-markdown-toc.go/pull/62))
+- A single shared HTTP client is reused instead of constructing one per request.
+  ([#62](https://github.com/ekalinin/github-markdown-toc.go/pull/62))
+- `gopkg.in/alecthomas/kingpin.v2` updated from v2.2.4 to v2.2.6, and the indirect module
+  graph was tidied. The CLI surface is unchanged.
+  ([#68](https://github.com/ekalinin/github-markdown-toc.go/pull/68))
+
+## [2.0.1] - 2026-04-03
+
+### Added
+
+- Support for GitHub's `codeViewBlobRoute` payload when reading a table of contents from a
+  blob page, alongside the existing `Payload.Blob` layout.
+
+### Fixed
+
+- Module paths corrected for the `/v2` module.
+  ([#55](https://github.com/ekalinin/github-markdown-toc.go/pull/55))
+
+## [2.0.0] - 2025-04-13
+
+### Changed
+
+- Rewritten on a clean/hexagonal architecture, splitting the CLI into `cmd`, application
+  wiring, controller, use cases, core model and adapters.
+  ([#52](https://github.com/ekalinin/github-markdown-toc.go/pull/52))
+- Module path moved to `github.com/ekalinin/github-markdown-toc.go/v2`.
+
+Releases before 2.0.0 are documented in the
+[GitHub releases](https://github.com/ekalinin/github-markdown-toc.go/releases) and in the
+git history.
+
+[Unreleased]: https://github.com/ekalinin/github-markdown-toc.go/compare/v2.0.1...master
+[2.0.1]: https://github.com/ekalinin/github-markdown-toc.go/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/ekalinin/github-markdown-toc.go/compare/v1.4.0...v2.0.0


### PR DESCRIPTION
## What changed

- **`CHANGELOG.md`** (new) - curated history in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Until now the only record of what changed between releases was the commit list GoReleaser generates on the release page, which does not distinguish a security fix from an internal refactor.
- **`.goreleaser.yaml`** - `release.footer` links the generated release page to `CHANGELOG.md`.
- **`AGENTS.md`** - records the rule: user-visible changes get an `[Unreleased]` entry in the same PR; behaviour-neutral refactors do not.

## About the `[Unreleased]` section

It covers everything merged since v2.0.1 and is written from **verified behaviour, not from commit subjects** - each entry was checked by building binaries from `v2.0.1` and from `master` and running them side by side:

| Scenario | v2.0.1 | master |
| --- | --- | --- |
| `GH_TOC_TOKEN` in `--debug` output | printed | not printed |
| `GH_TOC_URL` with no flag | ignored | honoured |
| missing file, exit code | 0 | 1 |
| unsupported `--re-version` | 0, silently empty TOC | 1 |
| output order for several files | varies between runs | argument order |
| temp files after a remote run | 1 left behind | 0 |

Two items are called out explicitly because upgraders must not miss them:

- the **GitHub token leaking into `--debug` output** up to and including 2.0.1, with an instruction to rotate any token used that way in CI;
- the **exit code changing from 0 to non-zero** on failure, which can change the behaviour of existing scripts.

The section also states up front that the generated TOC is byte-identical to 2.0.1 (`e2e-tests/want*.md` unchanged since the tag), since that is the first question an upgrader asks.

2.0.1 and 2.0.0 are filled in retrospectively; earlier releases are left to the GitHub releases page.

## Open question this closes

Whether GoReleaser's autogenerated notes stay or get replaced by a link to `CHANGELOG.md`. **They stay.** The commit list and the curated history serve different readers, so instead of removing one the release footer now points at the other.

## Validation

| Check | Result |
| --- | --- |
| `goreleaser check` | valid, no deprecation warnings |
| `goreleaser release --snapshot --clean` | succeeds with the new footer |
| `make test` (vet + golangci-lint + unit) | pass, 0 lint issues |
| All PR links in the changelog | resolved against `git log`, not guessed |

No Go source changed.