### PR TITLE
chore(gitignore): ignore debug HTML artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ TODO.md
 /gh-md-toc
 build
 e2e-tests/got*.md
+*.debug.html
 dist/
 .cover*


### PR DESCRIPTION
## What changed

One line in `.gitignore`: `*.debug.html`.

## Why

Running the CLI with `--debug` against a local document writes `<input>.debug.html` next to the input file (`internal/core/usecase/localmd/localmd.go`). For a document that lives in the repository - `./README.md` being the obvious one, since it is what `make e2e` and the README examples use - the artifact lands in the working tree as `README.md.debug.html`, shows up as untracked, and can be committed by accident.

Found while validating an unrelated change: a stray `README.md.debug.html` had accumulated in the working tree from earlier `--debug` runs.

## Validation

```
$ go run ./cmd/gh-md-toc --debug ./README.md >/dev/null
$ ls *.debug.html
README.md.debug.html
$ git status --short          # artifact no longer listed
$ git check-ignore -v README.md.debug.html
.gitignore:7:*.debug.html	README.md.debug.html
```

## Not in scope

Where the debug artifact should be written in the first place - in particular that for STDIN and remote inputs it lands next to the temporary file in `TMPDIR`, where nobody will find it. That belongs with the `// TODO: move to port` in `localmd.go`, not here.