### PR TITLE
fix(toc): prefix links with the document path for multiple inputs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -214,7 +214,7 @@ app.Config
     └── Indent int
 ```
 
-`cmd/gh-md-toc` maps flags and environment variables into this structure. `app.New` derives `TOC.AbsolutePaths` from whether the CLI received explicit file arguments.
+`cmd/gh-md-toc` maps flags and environment variables into this structure. `app.New` derives `TOC.AbsolutePaths` from whether the CLI received multiple file arguments, matching bash `gh-md-toc`, which drops the prefix when a single document is requested.
 
 Only the settings required at runtime are passed further:
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -262,12 +262,12 @@ Controller
   -> RemoteGetter.Get
   -> FileTemper.CreateTemp
   -> write downloaded Markdown
-  -> LocalMd.Do
+  -> LocalMd.DoAs
   -> remove temporary file
   -> entity.Toc
 ```
 
-`RemoteMd` reuses the complete local Markdown workflow after downloading the document. It validates the response media type as `text/plain` before creating the temporary file.
+`RemoteMd` reuses the complete local Markdown workflow after downloading the document. It validates the response media type as `text/plain` before creating the temporary file. It calls `LocalMd.DoAs` with the temporary file path and the original URL as the display path, so rendered links point at the source document instead of the temporary file.
 
 ### GitHub document page
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,7 +207,6 @@ app.Config
 │   ├── GHUrl string
 │   └── GHVersion string
 └── TOC toc.Config
-    ├── Path string
     ├── AbsolutePaths bool
     ├── StartDepth int
     ├── Depth int
@@ -309,7 +308,7 @@ The extractors only understand their external formats:
 - relative or absolute links;
 - Markdown list formatting.
 
-Both extraction paths use the same `Renderer` instance, which prevents formatting behavior from diverging.
+Both extraction paths use the same `Renderer` instance, which prevents formatting behavior from diverging. Because that instance is shared by the worker pool, the document path is passed into `Renderer.Render` and `Generator.Grab` as a call parameter rather than stored as renderer state.
 
 ## Concurrency and output ordering
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ e2e:
 	${E2E_RUN_RHTML} --hide-header --hide-footer --indent=4 > ${E2E_DIR}/got9.md
 	@diff ${E2E_DIR}/want3.md ${E2E_DIR}/got9.md
 
+	@echo "${bold}>> 4. Multiple files, links carry the document path ...${clear}"
+	go run ./cmd/${EXEC} --hide-footer ./README.md ./CHANGELOG.md > ${E2E_DIR}/got-combo.md
+	@grep -qF '](./README.md#' ${E2E_DIR}/got-combo.md
+	@grep -qF '](./CHANGELOG.md#' ${E2E_DIR}/got-combo.md
+
 # Step 2: create the release tag locally. Does not push anything.
 release: test release-local
 	@if git rev-parse -q --verify refs/tags/${TAG} >/dev/null; then \

--- a/internal/adapters/toc_rendering_integration_test.go
+++ b/internal/adapters/toc_rendering_integration_test.go
@@ -23,11 +23,11 @@ func TestJSONAndRegexpExtractorsRenderSameTOC(t *testing.T) {
 		{"level":2,"text":"Mandatory elements","anchor":"mandatory-elements"},
 		{"level":3,"text":"The command plug_list_versions","anchor":"plug_list_versions"}
 	]}}}}`
-	jsonTOC, err := jsonGenerator.Grab(context.Background(), jsonInput)
+	jsonTOC, err := jsonGenerator.Grab(context.Background(), "", jsonInput)
 	if err != nil {
 		t.Fatal(err)
 	}
-	regexpTOC, err := regexpGenerator.Grab(context.Background(), htmlHeadingsV2024)
+	regexpTOC, err := regexpGenerator.Grab(context.Background(), "", htmlHeadingsV2024)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -51,7 +51,8 @@ func New(cfg Config) (*App, error) {
 	}
 	jsonExtractor := adapters.NewJSONExtractor()
 	rendererCfg := cfg.TOC
-	rendererCfg.AbsolutePaths = len(cfg.Files) > 0
+	// bash gh-md-toc drops the path prefix only when a single document is requested.
+	rendererCfg.AbsolutePaths = len(cfg.Files) > 1
 	renderer := coretoc.NewRenderer(rendererCfg)
 	grabberRe := coretoc.NewGenerator(regexpExtractor, renderer)
 	grabberJSON := coretoc.NewGenerator(jsonExtractor, renderer)

--- a/internal/core/toc/generator.go
+++ b/internal/core/toc/generator.go
@@ -25,13 +25,15 @@ func NewGenerator(extractor HeadingExtractor, renderer *Renderer) *Generator {
 	}
 }
 
-func (g *Generator) Grab(ctx context.Context, input string) (*entity.Toc, error) {
+// Grab extracts headings from input and renders them as a TOC for the document at
+// path. The path is only used when the renderer is configured for absolute paths.
+func (g *Generator) Grab(ctx context.Context, path, input string) (*entity.Toc, error) {
 	headings, err := g.extractor.Extract(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("extract headings: %w", err)
 	}
 
-	result, err := g.renderer.Render(ctx, headings)
+	result, err := g.renderer.Render(ctx, path, headings)
 	if err != nil {
 		return nil, fmt.Errorf("render TOC: %w", err)
 	}

--- a/internal/core/toc/generator_test.go
+++ b/internal/core/toc/generator_test.go
@@ -26,7 +26,7 @@ func TestGeneratorRendersExtractedHeadings(t *testing.T) {
 	}}}
 	generator := NewGenerator(extractor, NewRenderer(DefaultConfig()))
 
-	got, err := generator.Grab(context.Background(), "input")
+	got, err := generator.Grab(context.Background(), "", "input")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestGeneratorPropagatesExtractorError(t *testing.T) {
 	extractorErr := errors.New("extract failed")
 	generator := NewGenerator(extractorStub{err: extractorErr}, NewRenderer(DefaultConfig()))
 
-	_, err := generator.Grab(context.Background(), "input")
+	_, err := generator.Grab(context.Background(), "", "input")
 	if !errors.Is(err, extractorErr) {
 		t.Fatalf("got error %v, want extractor error", err)
 	}
@@ -54,8 +54,28 @@ func TestGeneratorPropagatesRendererCancellation(t *testing.T) {
 		NewRenderer(DefaultConfig()),
 	)
 
-	_, err := generator.Grab(ctx, "input")
+	_, err := generator.Grab(ctx, "", "input")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("got error %v, want context cancellation", err)
+	}
+}
+
+func TestGeneratorPassesPathToRenderer(t *testing.T) {
+	extractor := extractorStub{headings: []entity.Heading{{
+		Level:  1,
+		Text:   "Title",
+		Anchor: "title",
+	}}}
+	cfg := DefaultConfig()
+	cfg.AbsolutePaths = true
+	generator := NewGenerator(extractor, NewRenderer(cfg))
+
+	got, err := generator.Grab(context.Background(), "docs/README.md", "input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := entity.Toc{"* [Title](docs/README.md#title)"}
+	if got == nil || !slices.Equal(*got, want) {
+		t.Errorf("got TOC %v, want %v", got, want)
 	}
 }

--- a/internal/core/toc/renderer.go
+++ b/internal/core/toc/renderer.go
@@ -9,7 +9,6 @@ import (
 
 // Config controls how headings are filtered and rendered as a Markdown TOC.
 type Config struct {
-	Path          string
 	AbsolutePaths bool
 	StartDepth    int
 	Depth         int
@@ -33,7 +32,9 @@ func NewRenderer(cfg Config) *Renderer {
 	return &Renderer{cfg: cfg}
 }
 
-func (r *Renderer) Render(ctx context.Context, headings []entity.Heading) (entity.Toc, error) {
+// Render turns headings into a Markdown TOC. When AbsolutePaths is set, path is
+// prefixed to every anchor, which is what multi-document mode needs.
+func (r *Renderer) Render(ctx context.Context, path string, headings []entity.Heading) (entity.Toc, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -68,7 +69,7 @@ func (r *Renderer) Render(ctx context.Context, headings []entity.Heading) (entit
 		}
 		link := "#" + heading.Anchor
 		if r.cfg.AbsolutePaths {
-			link = r.cfg.Path + link
+			link = path + link
 		}
 		indent := strings.Repeat(" ", max(0, heading.Level-baseLevel)*max(0, r.cfg.Indent))
 		result = append(result, indent+"* ["+text+"]("+link+")")

--- a/internal/core/toc/renderer_test.go
+++ b/internal/core/toc/renderer_test.go
@@ -19,6 +19,7 @@ func TestRendererRender(t *testing.T) {
 	tests := []struct {
 		name     string
 		cfg      Config
+		path     string
 		headings []entity.Heading
 		want     entity.Toc
 	}{
@@ -63,11 +64,11 @@ func TestRendererRender(t *testing.T) {
 		{
 			name: "absolute paths",
 			cfg: Config{
-				Path:          "README.md",
 				AbsolutePaths: true,
 				Escape:        true,
 				Indent:        2,
 			},
+			path: "README.md",
 			want: entity.Toc{
 				"* [Root\\.](README.md#root)",
 				"  * [Child\\_\\*](README.md#child_)",
@@ -117,7 +118,7 @@ func TestRendererRender(t *testing.T) {
 			if input == nil {
 				input = headings
 			}
-			got, err := NewRenderer(tt.cfg).Render(context.Background(), input)
+			got, err := NewRenderer(tt.cfg).Render(context.Background(), tt.path, input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -129,7 +130,7 @@ func TestRendererRender(t *testing.T) {
 }
 
 func TestRendererReturnsEmptyTOC(t *testing.T) {
-	got, err := NewRenderer(DefaultConfig()).Render(context.Background(), nil)
+	got, err := NewRenderer(DefaultConfig()).Render(context.Background(), "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,8 +142,51 @@ func TestRendererReturnsEmptyTOC(t *testing.T) {
 func TestRendererReturnsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := NewRenderer(DefaultConfig()).Render(ctx, []entity.Heading{{Level: 1}})
+	_, err := NewRenderer(DefaultConfig()).Render(ctx, "", []entity.Heading{{Level: 1}})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("got error %v, want context cancellation", err)
+	}
+}
+
+func TestRendererRenderPrefixesPath(t *testing.T) {
+	headings := []entity.Heading{
+		{Level: 1, Text: "Root", Anchor: "root"},
+		{Level: 2, Text: "Child", Anchor: "child"},
+	}
+	tests := []struct {
+		name string
+		cfg  Config
+		path string
+		want entity.Toc
+	}{
+		{
+			name: "absolute paths on",
+			cfg:  Config{AbsolutePaths: true, Escape: true, Indent: 2},
+			path: "docs/README.md",
+			want: entity.Toc{
+				"* [Root](docs/README.md#root)",
+				"  * [Child](docs/README.md#child)",
+			},
+		},
+		{
+			name: "absolute paths off ignores the path",
+			cfg:  Config{Escape: true, Indent: 2},
+			path: "docs/README.md",
+			want: entity.Toc{
+				"* [Root](#root)",
+				"  * [Child](#child)",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewRenderer(tt.cfg).Render(context.Background(), tt.path, headings)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("got TOC %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/core/usecase/localmd/localmd.go
+++ b/internal/core/usecase/localmd/localmd.go
@@ -53,7 +53,14 @@ func New(debug bool, checker fileChecker, writer fileWriter,
 	}
 }
 
+// Do builds the TOC for file, linking anchors relative to that same file.
 func (uc *LocalMd) Do(ctx context.Context, file string) (entity.Toc, error) {
+	return uc.DoAs(ctx, file, file)
+}
+
+// DoAs builds the TOC for file but renders links against displayPath. They differ
+// when the content was downloaded or trimmed into a temporary file.
+func (uc *LocalMd) DoAs(ctx context.Context, file, displayPath string) (entity.Toc, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("process local Markdown %q: %w", file, err)
 	}
@@ -86,7 +93,7 @@ func (uc *LocalMd) Do(ctx context.Context, file string) (entity.Toc, error) {
 	}
 
 	uc.log.Info("LocalMD: grabbing the TOC ...")
-	toc, err := uc.grabber.Grab(ctx, file, html)
+	toc, err := uc.grabber.Grab(ctx, displayPath, html)
 	if err != nil {
 		uc.log.Info("LocalMD: failed to grab TOC: %s", err)
 		return nil, fmt.Errorf("grab TOC from local Markdown %q: %w", file, err)

--- a/internal/core/usecase/localmd/localmd.go
+++ b/internal/core/usecase/localmd/localmd.go
@@ -21,7 +21,7 @@ type htmlConverter interface {
 }
 
 type tocGrabber interface {
-	Grab(context.Context, string) (*entity.Toc, error)
+	Grab(context.Context, string, string) (*entity.Toc, error)
 }
 
 type logger interface {
@@ -86,7 +86,7 @@ func (uc *LocalMd) Do(ctx context.Context, file string) (entity.Toc, error) {
 	}
 
 	uc.log.Info("LocalMD: grabbing the TOC ...")
-	toc, err := uc.grabber.Grab(ctx, html)
+	toc, err := uc.grabber.Grab(ctx, file, html)
 	if err != nil {
 		uc.log.Info("LocalMD: failed to grab TOC: %s", err)
 		return nil, fmt.Errorf("grab TOC from local Markdown %q: %w", file, err)

--- a/internal/core/usecase/localmd/localmd_test.go
+++ b/internal/core/usecase/localmd/localmd_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -38,11 +40,13 @@ func (s converterStub) Convert(context.Context, string) (string, error) {
 }
 
 type grabberStub struct {
-	toc *entity.Toc
-	err error
+	toc     *entity.Toc
+	err     error
+	gotPath string
 }
 
-func (s grabberStub) Grab(context.Context, string, string) (*entity.Toc, error) {
+func (s *grabberStub) Grab(_ context.Context, path, _ string) (*entity.Toc, error) {
+	s.gotPath = path
 	return s.toc, s.err
 }
 
@@ -57,7 +61,7 @@ func TestDoReturnsTOC(t *testing.T) {
 		checkerStub{exists: true},
 		writerStub{},
 		converterStub{html: "<h1>Title</h1>"},
-		grabberStub{toc: &want},
+		&grabberStub{toc: &want},
 		loggerStub{},
 	)
 
@@ -77,7 +81,7 @@ func TestDoAcceptsEmptyTOC(t *testing.T) {
 		checkerStub{exists: true},
 		writerStub{},
 		converterStub{},
-		grabberStub{toc: &empty},
+		&grabberStub{toc: &empty},
 		loggerStub{},
 	)
 
@@ -131,7 +135,7 @@ func TestDoPropagatesDependencyErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			uc := New(tt.debug, tt.checker, tt.writer, tt.converter, tt.grabber, loggerStub{})
+			uc := New(tt.debug, tt.checker, tt.writer, tt.converter, &tt.grabber, loggerStub{})
 			_, err := uc.Do(context.Background(), "broken.md")
 			if !errors.Is(err, dependencyErr) {
 				t.Fatalf("got error %v, want dependency error", err)
@@ -152,7 +156,7 @@ func TestDoReturnsErrorForMissingFile(t *testing.T) {
 		checkerStub{},
 		writerStub{},
 		converterStub{},
-		grabberStub{},
+		&grabberStub{},
 		loggerStub{},
 	)
 
@@ -174,12 +178,30 @@ func TestDoReturnsContextCancellation(t *testing.T) {
 		checkerStub{exists: true},
 		writerStub{},
 		converterStub{},
-		grabberStub{},
+		&grabberStub{},
 		loggerStub{},
 	)
 
 	_, err := uc.Do(ctx, "README.md")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("got error %v, want context cancellation", err)
+	}
+}
+
+func TestLocalMdDoAsUsesDisplayPath(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "source.md")
+	if err := os.WriteFile(file, []byte("# Title\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	grabber := &grabberStub{toc: &entity.Toc{"* [Title](#title)"}}
+	uc := New(false, checkerStub{exists: true}, writerStub{}, converterStub{html: "<h1>Title</h1>"}, grabber, loggerStub{})
+
+	if _, err := uc.DoAs(context.Background(), file, "https://example.com/README.md"); err != nil {
+		t.Fatal(err)
+	}
+	if grabber.gotPath != "https://example.com/README.md" {
+		t.Errorf("got grabber path %q, want the display path", grabber.gotPath)
 	}
 }

--- a/internal/core/usecase/localmd/localmd_test.go
+++ b/internal/core/usecase/localmd/localmd_test.go
@@ -42,7 +42,7 @@ type grabberStub struct {
 	err error
 }
 
-func (s grabberStub) Grab(context.Context, string) (*entity.Toc, error) {
+func (s grabberStub) Grab(context.Context, string, string) (*entity.Toc, error) {
 	return s.toc, s.err
 }
 

--- a/internal/core/usecase/remotehtml/remotehtml.go
+++ b/internal/core/usecase/remotehtml/remotehtml.go
@@ -16,7 +16,7 @@ type remoteGetter interface {
 }
 
 type tocGrabber interface {
-	Grab(context.Context, string) (*entity.Toc, error)
+	Grab(context.Context, string, string) (*entity.Toc, error)
 }
 
 type fileTemper interface {
@@ -103,7 +103,7 @@ func (r *RemoteHTML) Do(ctx context.Context, url string) (entity.Toc, error) {
 	}
 
 	r.log.Info("RemoteHTML: grabbing the TOC ...")
-	toc, err := r.grabber.Grab(ctx, string(jsonBody))
+	toc, err := r.grabber.Grab(ctx, url, string(jsonBody))
 	if err != nil {
 		r.log.Info("RemoteHTML: failed to grab TOC", "err", err)
 		return nil, fmt.Errorf("grab TOC from remote HTML %q: %w", url, err)

--- a/internal/core/usecase/remotehtml/remotehtml_test.go
+++ b/internal/core/usecase/remotehtml/remotehtml_test.go
@@ -43,7 +43,7 @@ type grabberStub struct {
 	err error
 }
 
-func (s grabberStub) Grab(context.Context, string) (*entity.Toc, error) {
+func (s grabberStub) Grab(context.Context, string, string) (*entity.Toc, error) {
 	return s.toc, s.err
 }
 

--- a/internal/core/usecase/remotemd/remotemd.go
+++ b/internal/core/usecase/remotemd/remotemd.go
@@ -16,7 +16,7 @@ type remoteGetter interface {
 }
 
 type markdownProcessor interface {
-	Do(context.Context, string) (entity.Toc, error)
+	DoAs(context.Context, string, string) (entity.Toc, error)
 }
 
 type fileTemper interface {
@@ -103,7 +103,7 @@ func (r *RemoteMd) Do(ctx context.Context, url string) (toc entity.Toc, err erro
 		}
 	}()
 
-	toc, err = r.ucLocalMD.Do(ctx, filename)
+	toc, err = r.ucLocalMD.DoAs(ctx, filename, url)
 	if err != nil {
 		return nil, fmt.Errorf("process remote Markdown %q: %w", url, err)
 	}

--- a/internal/core/usecase/remotemd/remotemd_test.go
+++ b/internal/core/usecase/remotemd/remotemd_test.go
@@ -64,11 +64,13 @@ func (s converterStub) Convert(context.Context, string) (string, error) {
 }
 
 type grabberStub struct {
-	toc *entity.Toc
-	err error
+	toc     *entity.Toc
+	err     error
+	gotPath string
 }
 
-func (s grabberStub) Grab(context.Context, string, string) (*entity.Toc, error) {
+func (s *grabberStub) Grab(_ context.Context, path, _ string) (*entity.Toc, error) {
+	s.gotPath = path
 	return s.toc, s.err
 }
 
@@ -108,7 +110,7 @@ func newUseCase(
 	temper temperStub,
 	writer writerStub,
 	converter converterStub,
-	grabber grabberStub,
+	grabber *grabberStub,
 ) *RemoteMd {
 	t.Helper()
 	local := localmd.New(
@@ -131,7 +133,7 @@ func TestDoReturnsTOC(t *testing.T) {
 		temper,
 		writerStub{},
 		converterStub{},
-		grabberStub{toc: &want},
+		&grabberStub{toc: &want},
 	)
 
 	got, err := uc.Do(context.Background(), "https://example.com/README.md")
@@ -154,7 +156,7 @@ func TestDoPropagatesDownloadError(t *testing.T) {
 		createTemper(t),
 		writerStub{},
 		converterStub{},
-		grabberStub{},
+		&grabberStub{},
 	)
 
 	const documentURL = "https://example.com/README.md"
@@ -179,7 +181,7 @@ func TestDoPropagatesTemporaryFileError(t *testing.T) {
 		},
 		writerStub{},
 		converterStub{},
-		grabberStub{},
+		&grabberStub{},
 	)
 
 	_, err := uc.Do(context.Background(), "https://example.com/README.md")
@@ -205,7 +207,7 @@ func TestDoCleansUpAfterTemporaryFileWriteError(t *testing.T) {
 		temper,
 		writerStub{},
 		converterStub{},
-		grabberStub{},
+		&grabberStub{},
 	)
 
 	_, err := uc.Do(context.Background(), "https://example.com/README.md")
@@ -226,7 +228,7 @@ func TestDoKeepsRemotePathForLocalProcessingError(t *testing.T) {
 		temper,
 		writerStub{},
 		converterStub{err: dependencyErr},
-		grabberStub{},
+		&grabberStub{},
 	)
 
 	const documentURL = "https://example.com/README.md"
@@ -249,7 +251,7 @@ func TestDoRejectsUnexpectedContentType(t *testing.T) {
 		createTemper(t),
 		writerStub{},
 		converterStub{},
-		grabberStub{},
+		&grabberStub{},
 	)
 
 	_, err := uc.Do(context.Background(), "https://example.com/README.md")
@@ -265,7 +267,7 @@ func TestDoRejectsMalformedContentType(t *testing.T) {
 		createTemper(t),
 		writerStub{},
 		converterStub{},
-		grabberStub{},
+		&grabberStub{},
 	)
 
 	_, err := uc.Do(context.Background(), "https://example.com/README.md")
@@ -287,11 +289,32 @@ func TestDoReturnsTemporaryFileRemovalError(t *testing.T) {
 		temper,
 		writerStub{},
 		converterStub{},
-		grabberStub{toc: &want},
+		&grabberStub{toc: &want},
 	)
 
 	_, err := uc.Do(context.Background(), "https://example.com/README.md")
 	if !errors.Is(err, removeErr) {
 		t.Fatalf("got error %v, want removal error", err)
+	}
+}
+
+func TestRemoteMdPassesURLAsDisplayPath(t *testing.T) {
+	want := entity.Toc{"* [Title](#title)"}
+	grabber := &grabberStub{toc: &want}
+	uc := newUseCase(
+		t,
+		getterStub{body: []byte("# Title"), contentType: "text/plain"},
+		createTemper(t),
+		writerStub{},
+		converterStub{},
+		grabber,
+	)
+
+	const documentURL = "https://example.com/README.md"
+	if _, err := uc.Do(context.Background(), documentURL); err != nil {
+		t.Fatal(err)
+	}
+	if grabber.gotPath != documentURL {
+		t.Errorf("got grabber path %q, want %q", grabber.gotPath, documentURL)
 	}
 }

--- a/internal/core/usecase/remotemd/remotemd_test.go
+++ b/internal/core/usecase/remotemd/remotemd_test.go
@@ -68,7 +68,7 @@ type grabberStub struct {
 	err error
 }
 
-func (s grabberStub) Grab(context.Context, string) (*entity.Toc, error) {
+func (s grabberStub) Grab(context.Context, string, string) (*entity.Toc, error) {
 	return s.toc, s.err
 }
 


### PR DESCRIPTION
## What changed

`coretoc.Config` had a `Path` field that nothing ever set, so `AbsolutePaths` had no visible effect. The document path now travels as a parameter through `Renderer.Render(ctx, path, headings)` and `Generator.Grab(ctx, path, input)` instead of living on the renderer, and `localmd` gained `DoAs(ctx, file, displayPath)` so a caller can state the display path separately from the file on disk.

`AbsolutePaths` is now `len(Files) > 1`, matching bash `gh-md-toc`, which drops the prefix when a single document is requested.

## Why

The "Multiple files" and "Combo" sections of the README have always documented output like `[Text](path/README.md#anchor)`, but the tool emitted `[Text](#anchor)` instead. `remotemd` downloads into a temporary file and delegates to `localmd`, so without a separate display path its links would have carried the temp path rather than the source URL.

The path must be a call parameter, not renderer state: a single `Renderer` is shared by the worker pool (`maxParallelFiles = 8`), so per-document state on it would be a data race.

## Compatibility

Multi-document runs change from `#anchor` to `path#anchor`. That is the behaviour the README always described. Single-document runs and STDIN are unchanged.

## Validation

```
go test ./...
go vet ./...
make e2e   # section 4 is new and covers this
```