### PR TITLE
feat(cli): add the STDIN marker, a token file and a fuller --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,14 @@ $ wget https://github.com/ekalinin/github-markdown-toc.go/releases/download/1.1.
 $ tar xzvf gh-md-toc.linux.amd64.tgz
 gh-md-toc
 $ ./gh-md-toc --version
-1.1.0
+2.0.1
+
+os:   darwin
+arch: arm64
+go:   go1.26.5
 ```
+
+The first line is the bare version number, so scripts that parse `gh-md-toc --version` will continue to work.
 
 Compiling from source
 ---------------------

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ gh-md-toc
 $ ./gh-md-toc --version
 2.0.1
 
-os:   darwin
-arch: arm64
+os:   linux
+arch: amd64
 go:   go1.26.5
 ```
 

--- a/cmd/gh-md-toc/config.go
+++ b/cmd/gh-md-toc/config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/app"
@@ -11,6 +13,7 @@ import (
 const (
 	cliName          = "gh-md-toc"
 	defaultGitHubURL = "https://api.github.com"
+	stdinMarker      = "-"
 )
 
 type cliOptions struct {
@@ -57,14 +60,39 @@ func newCLI() (*kingpin.Application, cliOptions) {
 	return parser, options
 }
 
+// extractStdinMarker removes the "-" STDIN marker from the argument list. The flag
+// parser would otherwise try to read it as a flag.
+func extractStdinMarker(args []string) ([]string, bool) {
+	found := false
+	rest := make([]string, 0, len(args))
+	for _, arg := range args {
+		if arg == stdinMarker {
+			found = true
+			continue
+		}
+		rest = append(rest, arg)
+	}
+	return rest, found
+}
+
 func parseConfig(args []string) (app.Config, error) {
+	args, useStdin := extractStdinMarker(args)
+
 	parser, options := newCLI()
 	if _, err := parser.Parse(args); err != nil {
 		return app.Config{}, err
 	}
 
+	files := *options.paths
+	if useStdin {
+		if len(files) > 0 {
+			return app.Config{}, errors.New(`the "-" STDIN marker cannot be combined with other paths`)
+		}
+		files = nil
+	}
+
 	return app.Config{
-		Files:  *options.paths,
+		Files:  files,
 		Serial: *options.serial,
 		Presentation: app.PresentationConfig{
 			HideHeader: *options.hideHeader,

--- a/cmd/gh-md-toc/config.go
+++ b/cmd/gh-md-toc/config.go
@@ -33,7 +33,7 @@ type cliOptions struct {
 
 func newCLI() (*kingpin.Application, cliOptions) {
 	parser := kingpin.New(cliName, "")
-	parser.Version(version.Version)
+	parser.Version(version.Full())
 
 	pathsDesc := "Local path or URL of the document to grab TOC. Read MD from stdin if not entered."
 	options := cliOptions{

--- a/cmd/gh-md-toc/config_test.go
+++ b/cmd/gh-md-toc/config_test.go
@@ -180,3 +180,23 @@ func TestCLIHelpShowsCurrentDefaultsWithoutToken(t *testing.T) {
 		t.Errorf("help contains GitHub token:\n%s", help)
 	}
 }
+
+func TestParseConfigStdinMarker(t *testing.T) {
+	cfg, err := parseConfig([]string{"-"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Files) != 0 {
+		t.Errorf("got files %v, want none so STDIN is used", cfg.Files)
+	}
+}
+
+func TestParseConfigStdinMarkerWithPaths(t *testing.T) {
+	_, err := parseConfig([]string{"-", "README.md"})
+	if err == nil {
+		t.Fatal("got no error, want a usage error")
+	}
+	if !strings.Contains(err.Error(), "STDIN marker") {
+		t.Errorf("got error %q, want it to mention the STDIN marker", err)
+	}
+}

--- a/internal/adapters/tokenresolver.go
+++ b/internal/adapters/tokenresolver.go
@@ -1,0 +1,41 @@
+package adapters
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const tokenFileName = "token.txt"
+
+// TokenResolver reads the GitHub token from a file next to the executable. It is the
+// last fallback, after the --token flag and the GH_TOC_TOKEN environment variable.
+type TokenResolver struct {
+	executable func() (string, error)
+}
+
+func NewTokenResolver() *TokenResolver {
+	return NewTokenResolverX(os.Executable)
+}
+
+func NewTokenResolverX(executable func() (string, error)) *TokenResolver {
+	return &TokenResolver{executable: executable}
+}
+
+// Resolve returns the token found in token.txt, or an empty string when there is no
+// such file. A missing file is not an error.
+func (r *TokenResolver) Resolve() (string, error) {
+	path, err := r.executable()
+	if err != nil {
+		return "", nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(filepath.Dir(path), tokenFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/internal/adapters/tokenresolver_test.go
+++ b/internal/adapters/tokenresolver_test.go
@@ -1,0 +1,57 @@
+package adapters
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTokenResolverResolve(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		write    bool
+		want     string
+	}{
+		{name: "no file", write: false, want: ""},
+		{name: "token with newline", write: true, contents: "abc123\n", want: "abc123"},
+		{name: "token with spaces", write: true, contents: "  abc123  ", want: "abc123"},
+		{name: "empty file", write: true, contents: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.write {
+				path := filepath.Join(dir, tokenFileName)
+				if err := os.WriteFile(path, []byte(tt.contents), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			resolver := NewTokenResolverX(func() (string, error) {
+				return filepath.Join(dir, "gh-md-toc"), nil
+			})
+
+			got, err := resolver.Resolve()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("got token %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenResolverIgnoresUnknownExecutablePath(t *testing.T) {
+	resolver := NewTokenResolverX(func() (string, error) {
+		return "", os.ErrNotExist
+	})
+
+	got, err := resolver.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("got token %q, want an empty string", got)
+	}
+}

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -41,6 +41,13 @@ func New(cfg Config) (*App, error) {
 	ctlCfg := controller.Config{Files: cfg.Files, Serial: cfg.Serial}
 
 	log.Info("App.New: init adapters ...")
+	if cfg.GitHub.GHToken == "" {
+		token, err := adapters.NewTokenResolver().Resolve()
+		if err != nil {
+			return nil, fmt.Errorf("read token file: %w", err)
+		}
+		cfg.GitHub.GHToken = token
+	}
 	httpClient := adapters.NewHTTPClient()
 	checker := adapters.NewFileCheck(log)
 	writer := adapters.NewFileWriter()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,5 +1,10 @@
 package version
 
+import (
+	"fmt"
+	"runtime"
+)
+
 const (
 	// Version is a current app version
 	Version   = "2.0.1"
@@ -20,4 +25,11 @@ func SupportedGHVersions() []string {
 		GH_2023_10,
 		GH_2024_03,
 	}
+}
+
+// Full returns the multi-line version banner. The first line stays the bare version
+// number, so scripts that parse `gh-md-toc --version` keep working.
+func Full() string {
+	return fmt.Sprintf("%s\n\nos:   %s\narch: %s\ngo:   %s",
+		Version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,23 @@
+package version
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestFullStartsWithBareVersion(t *testing.T) {
+	lines := strings.Split(Full(), "\n")
+	if lines[0] != Version {
+		t.Errorf("got first line %q, want the bare version %q", lines[0], Version)
+	}
+}
+
+func TestFullReportsPlatform(t *testing.T) {
+	full := Full()
+	for _, want := range []string{runtime.GOOS, runtime.GOARCH, runtime.Version()} {
+		if !strings.Contains(full, want) {
+			t.Errorf("got %q, want it to contain %q", full, want)
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #76. Review that one first.

## What changed

Three small parity gaps with bash `gh-md-toc`:

- `gh-md-toc -` reads STDIN. Invoking with no arguments still reads STDIN as before. Combining `-` with other paths is a usage error.
- The token is resolved as `--token` → `GH_TOC_TOKEN` → a `token.txt` file next to the executable. A missing file is not an error.
- `--version` reports the OS, architecture and Go version after the version number.

## Why

All three exist in the bash tool. The `-` marker is stripped from the argument list before the flag parser sees it, rather than relying on the parser to classify a bare dash as a positional argument.

`--version` keeps the bare version number on the first line, so anything parsing it keeps working.

## Compatibility

Additive. The only behaviour change for an existing invocation is the extra lines after the version number.

## Validation

```
go test ./...
go vet ./...
go run ./cmd/gh-md-toc --version
echo '# Title' | go run ./cmd/gh-md-toc -
```