### PR TITLE
feat(insert): add --insert and --no-backup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,6 +42,7 @@ cmd/gh-md-toc
         │   └── input routing, concurrency, and result output
         ├── internal/core/usecase
         │   ├── localmd
+        │   ├── insertmd (wraps localmd, only when --insert is set)
         │   ├── remotemd
         │   └── remotehtml
         ├── internal/core/toc
@@ -56,7 +57,8 @@ cmd/gh-md-toc
 internal/core/entity
 ├── Heading
 ├── Toc
-└── Type
+├── Type
+└── MarkerStart / MarkerEnd
 ```
 
 ## Dependency direction
@@ -93,9 +95,13 @@ Important dependency rules:
 ```mermaid
 flowchart TD
     AppNew[app.New] --> Logger
+    AppNew --> Notifier
     AppNew --> HTTPClient[http.Client]
     AppNew --> FileChecker
     AppNew --> FileWriter
+    AppNew --> FileReader
+    AppNew --> FileBackupper
+    AppNew --> Stamper
     AppNew --> FileTemper
     AppNew --> RemotePoster
     AppNew --> RemoteGetter
@@ -119,6 +125,14 @@ flowchart TD
     RegexpGenerator --> LocalMd
     Logger --> LocalMd
 
+    LocalMd --> InsertMd
+    FileReader --> InsertMd
+    FileWriter --> InsertMd
+    FileBackupper --> InsertMd
+    Stamper --> InsertMd
+    Notifier --> InsertMd
+    Logger --> InsertMd
+
     RemoteGetter --> RemoteMd
     FileTemper --> RemoteMd
     LocalMd --> RemoteMd
@@ -129,7 +143,8 @@ flowchart TD
     JSONGenerator --> RemoteHTML
     Logger --> RemoteHTML
 
-    LocalMd --> Controller
+    LocalMd -.->|"--insert not set"| Controller
+    InsertMd -.->|"--insert set"| Controller
     RemoteMd --> Controller
     RemoteHTML --> Controller
     Logger --> Controller
@@ -138,16 +153,25 @@ flowchart TD
 
 The shared `http.Client` gives all remote operations the same timeout configuration. The shared `Renderer` gives both extraction paths the same TOC formatting behavior.
 
+`InsertMd` wraps `LocalMd`, it does not replace it: `app.New` always builds the plain
+`LocalMd` and only builds `InsertMd` around it when `cfg.Insert.Enabled` is true. The
+controller then receives whichever of the two implements the local-file use case for
+that run. `RemoteMd` always keeps a direct reference to the unwrapped `LocalMd`,
+never to `InsertMd`, because it processes a downloaded temporary file and must never
+have a TOC written back into it.
+
 ## Main types and responsibilities
 
 | Package | Type | Responsibility |
 |---|---|---|
-| `internal/app` | `App` | Runs presentation logic before and after controller processing. |
-| `internal/app` | `Config` | Holds execution, presentation, GitHub, and TOC settings. |
+| `internal/app` | `App` | Runs presentation logic before and after controller processing, and warns about remote inputs when `--insert` is set. |
+| `internal/app` | `Config` | Holds execution, presentation, GitHub, TOC, and insert settings. |
 | `internal/app` | `PresentationConfig` | Controls header and footer visibility. |
 | `internal/app` | `GitHubConfig` | Holds the GitHub token, API URL, and regexp layout version. |
+| `internal/app` | `InsertConfig` | Controls whether the TOC is written into the source document and whether a backup is kept. |
 | `internal/controller` | `Controller` | Selects a use case, runs document jobs, preserves output order, and aggregates errors. |
 | `internal/core/usecase/localmd` | `LocalMd` | Validates a local file, converts Markdown through GitHub, and generates a TOC from returned HTML. |
+| `internal/core/usecase/insertmd` | `InsertMd` | Wraps `LocalMd`, then backs up and rewrites the block between the TOC markers in the source file. |
 | `internal/core/usecase/remotemd` | `RemoteMd` | Downloads raw Markdown to a temporary file and delegates processing to `LocalMd`. |
 | `internal/core/usecase/remotehtml` | `RemoteHTML` | Downloads GitHub JSON data and generates a TOC through the JSON path. |
 | `internal/core/toc` | `Generator` | Combines a heading extractor with the shared renderer. |
@@ -155,13 +179,18 @@ The shared `http.Client` gives all remote operations the same timeout configurat
 | `internal/core/entity` | `Heading` | Represents a parsed heading before Markdown rendering. |
 | `internal/core/entity` | `Toc` | Represents the generated TOC as Markdown lines and prints it. |
 | `internal/core/entity` | `Type` | Classifies an input as local Markdown, remote raw Markdown, or remote HTML. |
+| `internal/core/entity` | `MarkerStart` / `MarkerEnd` | The `<!--ts-->` / `<!--te-->` marker strings that delimit the TOC block inside a document. |
 | `internal/adapters` | `HTMLConverter` | Sends local Markdown to the GitHub Markdown API. |
 | `internal/adapters` | `RemotePoster` | Sends a file through the configured HTTP client. |
 | `internal/adapters` | `RemoteGetter` | Downloads remote content through the configured HTTP client. |
 | `internal/adapters` | `RegexpExtractor` | Extracts headings from GitHub-rendered HTML. |
 | `internal/adapters` | `JSONExtractor` | Extracts headings from a GitHub JSON response. |
 | `internal/adapters` | `FileChecker` | Checks whether a local file exists. |
-| `internal/adapters` | `FileWriter` | Writes debug content to a file. |
+| `internal/adapters` | `FileWriter` | Writes debug content to a file; also writes the rewritten document atomically for `InsertMd`. |
+| `internal/adapters` | `FileReader` | Reads a whole file into memory, for `InsertMd` to locate the markers. |
+| `internal/adapters` | `FileBackupper` | Copies a file to `<file>.orig.<timestamp>` before `InsertMd` rewrites it. |
+| `internal/adapters` | `Stamper` | Builds the signature comment recording who ran the insert and when. |
+| `internal/adapters` | `Notifier` | Writes status messages, such as the backup path or a non-local-input warning, to stderr. |
 | `internal/adapters` | `FileTemper` | Creates and removes temporary files. |
 | `internal/adapters` | `Logger` | Enables structured logging only in debug mode. |
 
@@ -172,15 +201,24 @@ Interfaces are intentionally small and located next to the consuming code.
 | Consumer | Interface | Implemented by |
 |---|---|---|
 | `app.App` | `app.Controller` | `*controller.Controller` |
-| `controller.Controller` | `controller.useCase` | `*localmd.LocalMd`, `*remotemd.RemoteMd`, `*remotehtml.RemoteHTML` |
+| `app.App` | `app.useCase` (used by `app.New`, not stored on `App`) | `*localmd.LocalMd`, `*insertmd.InsertMd` |
+| `app.App` | `app.notifier` | `*adapters.Notifier` |
+| `controller.Controller` | `controller.useCase` | `*localmd.LocalMd`, `*insertmd.InsertMd`, `*remotemd.RemoteMd`, `*remotehtml.RemoteHTML` |
 | `controller.Controller` | `controller.logger` | `*adapters.Logger` |
 | `localmd.LocalMd` | `localmd.fileChecker` | `*adapters.FileChecker` |
 | `localmd.LocalMd` | `localmd.fileWriter` | `*adapters.FileWriter` |
 | `localmd.LocalMd` | `localmd.htmlConverter` | `*adapters.HTMLConverter` |
 | `localmd.LocalMd` | `localmd.tocGrabber` | `*toc.Generator` |
 | `localmd.LocalMd` | `localmd.logger` | `*adapters.Logger` |
+| `insertmd.InsertMd` | `insertmd.useCase` | `*localmd.LocalMd` |
+| `insertmd.InsertMd` | `insertmd.fileReader` | `*adapters.FileReader` |
+| `insertmd.InsertMd` | `insertmd.atomicWriter` | `*adapters.FileWriter` |
+| `insertmd.InsertMd` | `insertmd.fileBackupper` | `*adapters.FileBackupper` |
+| `insertmd.InsertMd` | `insertmd.stamper` | `*adapters.Stamper` |
+| `insertmd.InsertMd` | `insertmd.notifier` | `*adapters.Notifier` |
+| `insertmd.InsertMd` | `insertmd.logger` | `*adapters.Logger` |
 | `remotemd.RemoteMd` | `remotemd.remoteGetter` | `*adapters.RemoteGetter` |
-| `remotemd.RemoteMd` | `remotemd.markdownProcessor` | `*localmd.LocalMd` |
+| `remotemd.RemoteMd` | `remotemd.markdownProcessor` | `*localmd.LocalMd` (always the unwrapped use case, never `*insertmd.InsertMd`) |
 | `remotemd.RemoteMd` | `remotemd.fileTemper` | `*adapters.FileTemper` |
 | `remotemd.RemoteMd` | `remotemd.logger` | `*adapters.Logger` |
 | `remotehtml.RemoteHTML` | `remotehtml.remoteGetter` | `*adapters.RemoteGetter` |
@@ -206,12 +244,15 @@ app.Config
 │   ├── GHToken string
 │   ├── GHUrl string
 │   └── GHVersion string
-└── TOC toc.Config
-    ├── AbsolutePaths bool
-    ├── StartDepth int
-    ├── Depth int
-    ├── Escape bool
-    └── Indent int
+├── TOC toc.Config
+│   ├── AbsolutePaths bool
+│   ├── StartDepth int
+│   ├── Depth int
+│   ├── Escape bool
+│   └── Indent int
+└── Insert app.InsertConfig
+    ├── Enabled bool
+    └── NoBackup bool
 ```
 
 `cmd/gh-md-toc` maps flags and environment variables into this structure. `app.New` derives `TOC.AbsolutePaths` from whether the CLI received multiple file arguments, matching bash `gh-md-toc`, which drops the prefix when a single document is requested.
@@ -222,7 +263,9 @@ Only the settings required at runtime are passed further:
 - `LocalMd` and `RemoteHTML` receive `Debug`;
 - `RemoteMd` receives no configuration;
 - `Renderer` receives `toc.Config`;
-- GitHub settings are used when constructing `HTMLConverter` and `RegexpExtractor`.
+- GitHub settings are used when constructing `HTMLConverter` and `RegexpExtractor`;
+- `InsertMd` receives `Insert.NoBackup` and `Presentation.HideFooter`; `app.Run` reads
+  `Insert.Enabled` directly to decide whether to warn about non-local inputs.
 
 ## Input routing
 
@@ -253,6 +296,38 @@ Controller
 ```
 
 When debug mode is enabled, `LocalMd` writes the returned HTML to `<input>.debug.html` through `FileWriter`.
+
+### Insert into the source file (`--insert`)
+
+```text
+Controller
+  -> InsertMd.Do
+  -> LocalMd.Do (builds the TOC, as above)
+  -> FileReader.Read
+  -> replaceBetweenMarkers (validate and rewrite the <!--ts--> / <!--te--> block)
+  -> FileBackupper.Backup      (skipped when --no-backup is set)
+  -> FileWriter.WriteAtomic
+  -> Notifier.Notify
+  -> entity.Toc
+```
+
+`InsertMd` wraps `LocalMd` rather than replacing it: it delegates to `LocalMd.Do` to
+obtain the TOC, then reads the current file, validates that it has exactly one
+`<!--ts-->` / `<!--te-->` marker pair in order, and rewrites only the block between
+them, byte for byte outside that block. The backup step runs before the rewrite so a
+failed rewrite still leaves a pristine copy on disk; it is skipped when
+`Insert.NoBackup` is set. `FileWriter.WriteAtomic` writes through a temporary file in
+the same directory and renames it over the target, so a failed write cannot truncate
+the original. `Notifier` reports the backup path and the rewritten path on stderr,
+separate from the TOC printed to stdout.
+
+`app.New` only builds `InsertMd` when `cfg.Insert.Enabled` is true; otherwise the
+controller receives the plain `LocalMd` for local files, unchanged from before this
+use case existed. `RemoteMd` is wired with the unwrapped `LocalMd` unconditionally, so
+downloading a remote document and then applying `--insert` to it never happens - the
+temporary file `RemoteMd` creates cannot be the target of a rewrite. `app.Run` warns
+on stderr, once per input, about any file passed alongside `--insert` that is not
+`entity.TypeLocalMD`, and otherwise leaves the document unmodified.
 
 ### Remote raw Markdown
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,12 @@ CMD_SRC=cmd/${EXEC}/main.go
 BUILD_DIR=build
 E2E_DIR=e2e-tests
 E2E_RUN=go run ./cmd/${EXEC} ./README.md
-E2E_RUN_RHTML=go run ./cmd/${EXEC} https://github.com/ekalinin/github-markdown-toc.go/blob/master/README.md
-E2E_RUN_RMD=go run ./cmd/${EXEC} https://raw.githubusercontent.com/ekalinin/github-markdown-toc.go/master/README.md
+# The remote e2e sections read README.md from GitHub. `master` is right once a branch
+# is merged; to run them on an unmerged branch, push it and pass its commit:
+#   make e2e E2E_REF=$(shell git rev-parse HEAD)
+E2E_REF?=master
+E2E_RUN_RHTML=go run ./cmd/${EXEC} https://github.com/ekalinin/github-markdown-toc.go/blob/${E2E_REF}/README.md
+E2E_RUN_RMD=go run ./cmd/${EXEC} https://raw.githubusercontent.com/ekalinin/github-markdown-toc.go/${E2E_REF}/README.md
 VERSION=$(shell grep "\tVersion" internal/version/version.go | grep -o -E '[0-9]\.[0-9]\.[0-9]{1,2}')
 TAG=v${VERSION}
 bold := $(shell tput bold)
@@ -62,6 +66,11 @@ e2e:
 	go run ./cmd/${EXEC} --hide-footer ./README.md ./CHANGELOG.md > ${E2E_DIR}/got-combo.md
 	@grep -qF '](./README.md#' ${E2E_DIR}/got-combo.md
 	@grep -qF '](./CHANGELOG.md#' ${E2E_DIR}/got-combo.md
+
+	@echo "${bold}>> 5. Insert into a local file ...${clear}"
+	@cp ${E2E_DIR}/insert-src.md ${E2E_DIR}/got-insert.md
+	go run ./cmd/${EXEC} --insert --no-backup --hide-footer ${E2E_DIR}/got-insert.md > /dev/null
+	@diff ${E2E_DIR}/want-insert.md ${E2E_DIR}/got-insert.md
 
 # Step 2: create the release tag locally. Does not push anything.
 release: test release-local

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Table of Contents
     * [Remote files](#remote-files)
     * [Multiple files](#multiple-files)
     * [Combo](#combo)
+    * [Insert into a file](#insert-into-a-file)
     * [Starting Depth](#starting-depth)
     * [Depth](#depth)
     * [No Escape](#no-escape)
@@ -101,6 +102,8 @@ Flags:
                    GitHub URL. Default: https://api.github.com
   --re-version=2024-03
                    RegExp version. Default: 2024-03
+  --insert         Insert the TOC into the file, between <!--ts--> and <!--te-->. Local files only
+  --no-backup      Do not keep a backup copy of the file. Requires --insert
   --version        Show application version.
 
 Args:
@@ -307,6 +310,36 @@ You can easily combine both ways:
 
 Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 ```
+
+Insert into a file
+------------------
+
+`gh-md-toc` can write the TOC directly into a document instead of only printing it.
+Add a marker line containing `<!--ts-->` where the TOC should start, and below it a
+marker line containing `<!--te-->` where it should end - each marker needs its own
+line, with nothing else on it besides surrounding whitespace. Then run:
+
+```bash
+$ ./gh-md-toc --insert README.md
+```
+
+Everything between the two markers is replaced with the generated TOC; the markers
+themselves and the rest of the document are left untouched. The `Table of Contents`
+heading is not written into the file, only the list itself.
+
+`--insert` only works on local files. A remote URL passed alongside `--insert` is
+reported as not local and left unmodified, instead of failing the whole run.
+
+Before rewriting the file, a backup copy is kept next to it, named
+`<file>.orig.<timestamp>`. Pass `--no-backup` to skip the backup; that flag requires
+`--insert` and is rejected on its own.
+
+Unless `--hide-footer` is set, an attribution comment and a signature comment (who
+ran the command, and when) are written right after the TOC, inside the markers.
+`--hide-footer` suppresses both.
+
+Status messages - the backup path, or a warning about a non-local input - are
+printed to stderr, not stdout.
 
 Starting Depth
 --------------

--- a/cmd/gh-md-toc/config.go
+++ b/cmd/gh-md-toc/config.go
@@ -29,6 +29,8 @@ type cliOptions struct {
 	debug      *bool
 	githubURL  *string
 	reVersion  *string
+	insert     *bool
+	noBackup   *bool
 }
 
 func newCLI() (*kingpin.Application, cliOptions) {
@@ -55,6 +57,14 @@ func newCLI() (*kingpin.Application, cliOptions) {
 			"re-version",
 			"RegExp version. Default: "+version.GH_2024_03,
 		).Default(version.GH_2024_03).Enum(version.SupportedGHVersions()...),
+		insert: parser.Flag(
+			"insert",
+			"Insert the TOC into the file, between <!--ts--> and <!--te-->. Local files only",
+		).Bool(),
+		noBackup: parser.Flag(
+			"no-backup",
+			"Do not keep a backup copy of the file. Requires --insert",
+		).Bool(),
 	}
 
 	return parser, options
@@ -91,6 +101,10 @@ func parseConfig(args []string) (app.Config, error) {
 		files = nil
 	}
 
+	if *options.noBackup && !*options.insert {
+		return app.Config{}, errors.New("--no-backup requires --insert")
+	}
+
 	return app.Config{
 		Files:  files,
 		Serial: *options.serial,
@@ -108,6 +122,10 @@ func parseConfig(args []string) (app.Config, error) {
 			Depth:      *options.depth,
 			Escape:     !*options.noEscape,
 			Indent:     *options.indent,
+		},
+		Insert: app.InsertConfig{
+			Enabled:  *options.insert,
+			NoBackup: *options.noBackup,
 		},
 		Debug: *options.debug,
 	}, nil

--- a/cmd/gh-md-toc/config_test.go
+++ b/cmd/gh-md-toc/config_test.go
@@ -200,3 +200,23 @@ func TestParseConfigStdinMarkerWithPaths(t *testing.T) {
 		t.Errorf("got error %q, want it to mention the STDIN marker", err)
 	}
 }
+
+func TestParseConfigInsertFlags(t *testing.T) {
+	cfg, err := parseConfig([]string{"--insert", "--no-backup", "README.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Insert.Enabled || !cfg.Insert.NoBackup {
+		t.Errorf("got insert config %+v, want both flags set", cfg.Insert)
+	}
+}
+
+func TestParseConfigNoBackupRequiresInsert(t *testing.T) {
+	_, err := parseConfig([]string{"--no-backup", "README.md"})
+	if err == nil {
+		t.Fatal("got no error, want a usage error")
+	}
+	if !strings.Contains(err.Error(), "--no-backup requires --insert") {
+		t.Errorf("got error %q, want it to explain the dependency", err)
+	}
+}

--- a/cmd/gh-md-toc/main.go
+++ b/cmd/gh-md-toc/main.go
@@ -30,7 +30,7 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	application, err := app.New(cfg)
+	application, err := app.New(cfg, stderr)
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, err)
 		return 1

--- a/e2e-tests/insert-src.md
+++ b/e2e-tests/insert-src.md
@@ -1,0 +1,8 @@
+# Title
+
+<!--ts-->
+<!--te-->
+
+## Section one
+
+## Section two

--- a/e2e-tests/want-insert.md
+++ b/e2e-tests/want-insert.md
@@ -1,0 +1,11 @@
+# Title
+
+<!--ts-->
+* [Title](#title)
+  * [Section one](#section-one)
+  * [Section two](#section-two)
+<!--te-->
+
+## Section one
+
+## Section two

--- a/e2e-tests/want.md
+++ b/e2e-tests/want.md
@@ -16,6 +16,7 @@ Table of Contents
   * [Remote files](#remote-files)
   * [Multiple files](#multiple-files)
   * [Combo](#combo)
+  * [Insert into a file](#insert-into-a-file)
   * [Starting Depth](#starting-depth)
   * [Depth](#depth)
   * [No escape](#no-escape)

--- a/e2e-tests/want3.md
+++ b/e2e-tests/want3.md
@@ -12,6 +12,7 @@
     * [Remote files](#remote-files)
     * [Multiple files](#multiple-files)
     * [Combo](#combo)
+    * [Insert into a file](#insert-into-a-file)
     * [Starting Depth](#starting-depth)
     * [Depth](#depth)
     * [No escape](#no-escape)

--- a/internal/adapters/filebackup.go
+++ b/internal/adapters/filebackup.go
@@ -24,6 +24,9 @@ func NewFileBackupperX(now func() time.Time) *FileBackupper {
 }
 
 // Backup copies file to "<file>.orig.<timestamp>" and returns the path of the copy.
+// An existing backup is never overwritten. The timestamp has one-second granularity,
+// so a second run within the same second would otherwise replace the pristine copy
+// with an already-rewritten one.
 func (b *FileBackupper) Backup(ctx context.Context, file string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
@@ -39,8 +42,17 @@ func (b *FileBackupper) Backup(ctx context.Context, file string) (string, error)
 	}
 
 	backup := fmt.Sprintf("%s.orig.%s", file, b.now().Format(backupTimeLayout))
-	if err := os.WriteFile(backup, data, info.Mode().Perm()); err != nil {
+	dst, err := os.OpenFile(backup, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	if err != nil {
 		return "", err
+	}
+	_, writeErr := dst.Write(data)
+	closeErr := dst.Close()
+	if writeErr != nil {
+		return "", writeErr
+	}
+	if closeErr != nil {
+		return "", closeErr
 	}
 	return backup, nil
 }

--- a/internal/adapters/filebackup.go
+++ b/internal/adapters/filebackup.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -48,11 +49,10 @@ func (b *FileBackupper) Backup(ctx context.Context, file string) (string, error)
 	}
 	_, writeErr := dst.Write(data)
 	closeErr := dst.Close()
-	if writeErr != nil {
-		return "", writeErr
-	}
-	if closeErr != nil {
-		return "", closeErr
+	if err := errors.Join(writeErr, closeErr); err != nil {
+		// The exclusive create already claimed the path. Leaving a partial copy there
+		// would block a retry with EEXIST and hide the error that actually happened.
+		return "", errors.Join(err, os.Remove(backup))
 	}
 	return backup, nil
 }

--- a/internal/adapters/filebackup.go
+++ b/internal/adapters/filebackup.go
@@ -1,0 +1,46 @@
+package adapters
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+)
+
+// backupTimeLayout matches the suffix the bash gh-md-toc uses for its backups.
+const backupTimeLayout = "2006-01-02_150405"
+
+// FileBackupper copies a file next to itself before it gets rewritten.
+type FileBackupper struct {
+	now func() time.Time
+}
+
+func NewFileBackupper() *FileBackupper {
+	return NewFileBackupperX(time.Now)
+}
+
+func NewFileBackupperX(now func() time.Time) *FileBackupper {
+	return &FileBackupper{now: now}
+}
+
+// Backup copies file to "<file>.orig.<timestamp>" and returns the path of the copy.
+func (b *FileBackupper) Backup(ctx context.Context, file string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	info, err := os.Stat(file)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+
+	backup := fmt.Sprintf("%s.orig.%s", file, b.now().Format(backupTimeLayout))
+	if err := os.WriteFile(backup, data, info.Mode().Perm()); err != nil {
+		return "", err
+	}
+	return backup, nil
+}

--- a/internal/adapters/filebackup_test.go
+++ b/internal/adapters/filebackup_test.go
@@ -48,3 +48,33 @@ func TestFileBackupperMissingFile(t *testing.T) {
 		t.Fatal("got no error, want a missing file error")
 	}
 }
+
+func TestFileBackupperRefusesToOverwriteExistingBackup(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(file, []byte("original\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Date(2026, 8, 12, 13, 45, 6, 0, time.UTC)
+	backupper := NewFileBackupperX(func() time.Time { return stamp })
+
+	first, err := backupper.Backup(context.Background(), file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("changed\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := backupper.Backup(context.Background(), file); err == nil {
+		t.Fatal("got no error, want a refusal to overwrite the existing backup")
+	}
+
+	data, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "original\n" {
+		t.Errorf("got backup contents %q, want the pristine original", data)
+	}
+}

--- a/internal/adapters/filebackup_test.go
+++ b/internal/adapters/filebackup_test.go
@@ -1,0 +1,50 @@
+package adapters
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileBackupperBackup(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(file, []byte("original\n"), 0640); err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Date(2026, 8, 12, 13, 45, 6, 0, time.UTC)
+
+	got, err := NewFileBackupperX(func() time.Time { return stamp }).Backup(context.Background(), file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := file + ".orig.2026-08-12_134506"
+	if got != want {
+		t.Errorf("got backup path %q, want %q", got, want)
+	}
+	data, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "original\n" {
+		t.Errorf("got backup contents %q, want %q", data, "original\n")
+	}
+	info, err := os.Stat(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0640 {
+		t.Errorf("got backup mode %v, want 0640", info.Mode().Perm())
+	}
+}
+
+func TestFileBackupperMissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := NewFileBackupper().Backup(context.Background(), filepath.Join(dir, "absent.md")); err == nil {
+		t.Fatal("got no error, want a missing file error")
+	}
+}

--- a/internal/adapters/filereader.go
+++ b/internal/adapters/filereader.go
@@ -1,0 +1,20 @@
+package adapters
+
+import (
+	"context"
+	"os"
+)
+
+// FileReader reads a whole file into memory.
+type FileReader struct{}
+
+func NewFileReader() *FileReader {
+	return &FileReader{}
+}
+
+func (f *FileReader) Read(ctx context.Context, file string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(file)
+}

--- a/internal/adapters/filereader_test.go
+++ b/internal/adapters/filereader_test.go
@@ -1,0 +1,33 @@
+package adapters
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileReaderRead(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "doc.md")
+	if err := os.WriteFile(file, []byte("# Title\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := NewFileReader().Read(context.Background(), file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "# Title\n" {
+		t.Errorf("got %q, want %q", got, "# Title\n")
+	}
+}
+
+func TestFileReaderReadCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := NewFileReader().Read(ctx, "irrelevant.md"); err == nil {
+		t.Fatal("got no error, want context cancellation")
+	}
+}

--- a/internal/adapters/filewriter.go
+++ b/internal/adapters/filewriter.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"context"
 	"os"
+	"path/filepath"
 )
 
 type FileWriter struct{}
@@ -16,4 +17,42 @@ func (f *FileWriter) Write(ctx context.Context, file string, data []byte) error 
 		return err
 	}
 	return os.WriteFile(file, data, 0644)
+}
+
+// WriteAtomic writes data through a temporary file in the same directory and renames
+// it over the target, so a failed write can never truncate the original. The existing
+// file mode is preserved.
+func (f *FileWriter) WriteAtomic(ctx context.Context, file string, data []byte) (err error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	perm := os.FileMode(0644)
+	if info, statErr := os.Stat(file); statErr == nil {
+		perm = info.Mode().Perm()
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(file), filepath.Base(file)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err = tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	if err = os.Chmod(tmpPath, perm); err != nil {
+		return err
+	}
+	err = os.Rename(tmpPath, file)
+	return err
 }

--- a/internal/adapters/filewriter_test.go
+++ b/internal/adapters/filewriter_test.go
@@ -91,3 +91,28 @@ func TestFileWriterWriteAtomicFailsWithoutDirectory(t *testing.T) {
 		t.Error("got a leftover directory, want nothing created")
 	}
 }
+
+func TestFileWriterWriteAtomicRemovesTempFileOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Renaming onto a directory fails, and by then the temp file exists.
+	target := filepath.Join(dir, "target")
+	if err := os.Mkdir(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewFileWriter().WriteAtomic(context.Background(), target, []byte("new\n")); err == nil {
+		t.Fatal("got no error, want the rename onto a directory to fail")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "target" {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		t.Errorf("got directory entries %v, want only the target - the temp file must be removed", names)
+	}
+}

--- a/internal/adapters/filewriter_test.go
+++ b/internal/adapters/filewriter_test.go
@@ -45,3 +45,49 @@ func Test_FileWriter(t *testing.T) {
 		})
 	}
 }
+
+func TestFileWriterWriteAtomicPreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(file, []byte("old\n"), 0640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewFileWriter().WriteAtomic(context.Background(), file, []byte("new\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "new\n" {
+		t.Errorf("got %q, want %q", data, "new\n")
+	}
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0640 {
+		t.Errorf("got mode %v, want 0640", info.Mode().Perm())
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("got %d files in the directory, want only the target file", len(entries))
+	}
+}
+
+func TestFileWriterWriteAtomicFailsWithoutDirectory(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "sub", "README.md")
+
+	if err := NewFileWriter().WriteAtomic(context.Background(), file, []byte("new\n")); err == nil {
+		t.Fatal("got no error, want a failure for a missing directory")
+	}
+	if _, err := os.Stat(dir + "/sub"); !os.IsNotExist(err) {
+		t.Error("got a leftover directory, want nothing created")
+	}
+}

--- a/internal/adapters/notifier.go
+++ b/internal/adapters/notifier.go
@@ -1,0 +1,23 @@
+package adapters
+
+import (
+	"fmt"
+	"io"
+)
+
+// Notifier writes status messages for the user. They go to a stream separate from
+// the TOC itself, because the worker pool emits them in completion order.
+type Notifier struct {
+	w io.Writer
+}
+
+func NewNotifier(w io.Writer) *Notifier {
+	return &Notifier{w: w}
+}
+
+func (n *Notifier) Notify(format string, args ...any) {
+	if n.w == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(n.w, format+"\n", args...)
+}

--- a/internal/adapters/notifier_test.go
+++ b/internal/adapters/notifier_test.go
@@ -1,0 +1,20 @@
+package adapters
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNotifierNotify(t *testing.T) {
+	var buf bytes.Buffer
+	NewNotifier(&buf).Notify("!! TOC was added into: %q", "README.md")
+
+	want := "!! TOC was added into: \"README.md\"\n"
+	if buf.String() != want {
+		t.Errorf("got %q, want %q", buf.String(), want)
+	}
+}
+
+func TestNotifierNilWriter(t *testing.T) {
+	NewNotifier(nil).Notify("ignored %s", "message")
+}

--- a/internal/adapters/stamper.go
+++ b/internal/adapters/stamper.go
@@ -1,0 +1,38 @@
+package adapters
+
+import (
+	"fmt"
+	"os/user"
+	"time"
+)
+
+// Stamper builds the signature comment written into a document next to an
+// inserted TOC.
+type Stamper struct {
+	now      func() time.Time
+	username func() (string, error)
+}
+
+func NewStamper() *Stamper {
+	return NewStamperX(time.Now, currentUsername)
+}
+
+func NewStamperX(now func() time.Time, username func() (string, error)) *Stamper {
+	return &Stamper{now: now, username: username}
+}
+
+func currentUsername() (string, error) {
+	current, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return current.Username, nil
+}
+
+func (s *Stamper) Stamp() string {
+	name, err := s.username()
+	if err != nil || name == "" {
+		name = "unknown"
+	}
+	return fmt.Sprintf("<!-- Added by: %s, at: %s -->", name, s.now().Format(time.RFC3339))
+}

--- a/internal/adapters/stamper_test.go
+++ b/internal/adapters/stamper_test.go
@@ -1,0 +1,40 @@
+package adapters
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestStamperStamp(t *testing.T) {
+	stamp := time.Date(2026, 8, 12, 13, 45, 6, 0, time.UTC)
+	tests := []struct {
+		name     string
+		username func() (string, error)
+		want     string
+	}{
+		{
+			name:     "known user",
+			username: func() (string, error) { return "ekalinin", nil },
+			want:     "<!-- Added by: ekalinin, at: 2026-08-12T13:45:06Z -->",
+		},
+		{
+			name:     "lookup fails",
+			username: func() (string, error) { return "", errors.New("no user") },
+			want:     "<!-- Added by: unknown, at: 2026-08-12T13:45:06Z -->",
+		},
+		{
+			name:     "empty user",
+			username: func() (string, error) { return "", nil },
+			want:     "<!-- Added by: unknown, at: 2026-08-12T13:45:06Z -->",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewStamperX(func() time.Time { return stamp }, tt.username).Stamp()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	Presentation PresentationConfig
 	GitHub       GitHubConfig
 	TOC          coretoc.Config
+	Insert       InsertConfig
 	Debug        bool
 }
 
@@ -23,4 +24,10 @@ type GitHubConfig struct {
 	GHToken   string
 	GHUrl     string
 	GHVersion string
+}
+
+// InsertConfig controls rewriting the TOC inside the source document.
+type InsertConfig struct {
+	Enabled  bool
+	NoBackup bool
 }

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/adapters"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/controller"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 	coretoc "github.com/ekalinin/github-markdown-toc.go/v2/internal/core/toc"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/insertmd"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/localmd"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/remotehtml"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/remotemd"
@@ -17,13 +19,23 @@ type Controller interface {
 	Process(ctx context.Context, stdout io.Writer) error
 }
 
-type App struct {
-	cfg Config
-	ctl Controller
+type useCase interface {
+	Do(ctx context.Context, file string) (entity.Toc, error)
 }
 
-func New(cfg Config) (*App, error) {
+type notifier interface {
+	Notify(format string, args ...any)
+}
+
+type App struct {
+	cfg    Config
+	ctl    Controller
+	notify notifier
+}
+
+func New(cfg Config, stderr io.Writer) (*App, error) {
 	log := adapters.NewLogger(cfg.Debug)
+	notify := adapters.NewNotifier(stderr)
 
 	log.Info(
 		"App.New: init configs ...",
@@ -37,6 +49,8 @@ func New(cfg Config) (*App, error) {
 		"indent", cfg.TOC.Indent,
 		"github-version", cfg.GitHub.GHVersion,
 		"token-configured", cfg.GitHub.GHToken != "",
+		"insert", cfg.Insert.Enabled,
+		"no-backup", cfg.Insert.NoBackup,
 	)
 	ctlCfg := controller.Config{Files: cfg.Files, Serial: cfg.Serial}
 
@@ -65,18 +79,34 @@ func New(cfg Config) (*App, error) {
 	grabberJSON := coretoc.NewGenerator(jsonExtractor, renderer)
 	getter := adapters.NewRemoteGetterWithClient(true, httpClient)
 	temper := adapters.NewFileTemper()
+	reader := adapters.NewFileReader()
+	backupper := adapters.NewFileBackupper()
+	stamper := adapters.NewStamper()
 
 	log.Info("App.New: init usecases ...")
 	ucLocalMD := localmd.New(cfg.Debug, checker, writer, converter, grabberRe, log)
+
+	var ucLocal useCase = ucLocalMD
+	if cfg.Insert.Enabled {
+		ucLocal = insertmd.New(
+			insertmd.Config{
+				NoBackup:   cfg.Insert.NoBackup,
+				HideFooter: cfg.Presentation.HideFooter,
+			},
+			ucLocalMD, reader, writer, backupper, stamper, notify, log,
+		)
+	}
+
 	ucRemoteMD := remotemd.New(getter, ucLocalMD, temper, log)
 	ucRemoteHTML := remotehtml.New(cfg.Debug, getter, temper, grabberJSON, log)
 
 	log.Info("App.New: init controller ...")
-	ctl := controller.New(ctlCfg, ucLocalMD, ucRemoteMD, ucRemoteHTML, log)
+	ctl := controller.New(ctlCfg, ucLocal, ucRemoteMD, ucRemoteHTML, log)
 
 	log.Info("App.New: done.")
 	return &App{
-		ctl: ctl,
-		cfg: cfg,
+		ctl:    ctl,
+		cfg:    cfg,
+		notify: notify,
 	}, nil
 }

--- a/internal/app/new_test.go
+++ b/internal/app/new_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -25,7 +26,7 @@ func TestNewDoesNotLogGitHubToken(t *testing.T) {
 			GHUrl:     "https://api.github.com",
 			GHVersion: version.GH_2024_03,
 		},
-	})
+	}, io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +41,7 @@ func TestNewDoesNotLogGitHubToken(t *testing.T) {
 }
 
 func TestNewRejectsUnknownRegexpVersion(t *testing.T) {
-	_, err := New(Config{GitHub: GitHubConfig{GHVersion: "unknown"}})
+	_, err := New(Config{GitHub: GitHubConfig{GHVersion: "unknown"}}, io.Discard)
 	if err == nil {
 		t.Fatal("expected an error for an unsupported regexp version")
 	}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -4,9 +4,18 @@ import (
 	"context"
 	"fmt"
 	"io"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
 )
 
 func (a *App) Run(ctx context.Context, stdout io.Writer) error {
+	if a.cfg.Insert.Enabled {
+		for _, file := range a.cfg.Files {
+			if entity.GetType(file) != entity.TypeLocalMD {
+				a.notify.Notify("!! %q is not a local file, can't insert the TOC into it", file)
+			}
+		}
+	}
 
 	// do not show for stdin case (Files is empty)
 	if !a.cfg.Presentation.HideHeader && len(a.cfg.Files) == 1 {

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
 
 type TestController struct {
@@ -64,5 +66,26 @@ func Test_AppRunFail(t *testing.T) {
 	}
 	if !strings.Contains(b.String(), "partial result") {
 		t.Errorf("successful partial output was lost: %q", b.String())
+	}
+}
+
+func TestRunWarnsAboutRemoteInputsWithInsert(t *testing.T) {
+	var stderr bytes.Buffer
+	cfg := Config{
+		Files:  []string{"https://github.com/ekalinin/envirius/blob/master/README.md"},
+		Insert: InsertConfig{Enabled: true},
+		GitHub: GitHubConfig{GHVersion: version.GH_2024_03},
+	}
+	application, err := New(cfg, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	application.ctl = TestController{}
+
+	if err := application.Run(context.Background(), &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr.String(), "is not a local file") {
+		t.Errorf("got stderr %q, want the not-a-local-file warning", stderr.String())
 	}
 }

--- a/internal/core/entity/marker.go
+++ b/internal/core/entity/marker.go
@@ -1,0 +1,7 @@
+package entity
+
+// MarkerStart and MarkerEnd delimit the TOC block inside a Markdown document.
+const (
+	MarkerStart = "<!--ts-->"
+	MarkerEnd   = "<!--te-->"
+)

--- a/internal/core/usecase/insertmd/insertmd.go
+++ b/internal/core/usecase/insertmd/insertmd.go
@@ -1,0 +1,124 @@
+package insertmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+)
+
+// createdBy is the attribution written into the document, next to the TOC.
+const createdBy = "<!-- Created by https://github.com/ekalinin/github-markdown-toc.go -->"
+
+type useCase interface {
+	Do(context.Context, string) (entity.Toc, error)
+}
+
+type fileReader interface {
+	Read(context.Context, string) ([]byte, error)
+}
+
+type atomicWriter interface {
+	WriteAtomic(context.Context, string, []byte) error
+}
+
+type fileBackupper interface {
+	Backup(context.Context, string) (string, error)
+}
+
+type stamper interface {
+	Stamp() string
+}
+
+type notifier interface {
+	Notify(string, ...any)
+}
+
+type logger interface {
+	Info(string, ...any)
+}
+
+// Config controls how the TOC block is written back into the document.
+type Config struct {
+	NoBackup   bool
+	HideFooter bool
+}
+
+// - delegate to the inner use case to build the TOC
+// - back up the original file
+// - rewrite the block between <!--ts--> and <!--te-->
+type InsertMd struct {
+	cfg       Config
+	inner     useCase
+	reader    fileReader
+	writer    atomicWriter
+	backupper fileBackupper
+	stamp     stamper
+	notify    notifier
+	log       logger
+}
+
+func New(cfg Config, inner useCase, reader fileReader, writer atomicWriter,
+	backupper fileBackupper, stamp stamper, notify notifier, log logger) *InsertMd {
+	return &InsertMd{
+		cfg:       cfg,
+		inner:     inner,
+		reader:    reader,
+		writer:    writer,
+		backupper: backupper,
+		stamp:     stamp,
+		notify:    notify,
+		log:       log,
+	}
+}
+
+// block renders what goes between the markers: the TOC itself plus, unless the
+// footer is hidden, the attribution and the signature.
+func (uc *InsertMd) block(toc entity.Toc) []byte {
+	lines := make([]string, 0, len(toc)+3)
+	lines = append(lines, toc...)
+	if !uc.cfg.HideFooter {
+		lines = append(lines, "", createdBy, uc.stamp.Stamp())
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func (uc *InsertMd) Do(ctx context.Context, file string) (entity.Toc, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("insert TOC into %q: %w", file, err)
+	}
+
+	uc.log.Info("InsertMD: start", "file", file)
+	toc, err := uc.inner.Do(ctx, file)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := uc.reader.Read(ctx, file)
+	if err != nil {
+		return nil, fmt.Errorf("read %q for TOC insertion: %w", file, err)
+	}
+
+	// Validate before the backup, so a document without markers leaves nothing behind.
+	updated, err := replaceBetweenMarkers(content, uc.block(toc))
+	if err != nil {
+		return nil, fmt.Errorf("insert TOC into %q: %w", file, err)
+	}
+
+	if !uc.cfg.NoBackup {
+		backup, backupErr := uc.backupper.Backup(ctx, file)
+		if backupErr != nil {
+			return nil, fmt.Errorf("back up %q: %w", file, backupErr)
+		}
+		uc.notify.Notify("!! Origin version of the file: %q", backup)
+	}
+
+	if err := uc.writer.WriteAtomic(ctx, file, updated); err != nil {
+		return nil, fmt.Errorf("insert TOC into %q: %w", file, err)
+	}
+	uc.notify.Notify("!! TOC was added into: %q", file)
+
+	uc.log.Info("InsertMD: done.")
+	return toc, nil
+}

--- a/internal/core/usecase/insertmd/insertmd_test.go
+++ b/internal/core/usecase/insertmd/insertmd_test.go
@@ -147,3 +147,56 @@ func TestInsertMdPropagatesInnerError(t *testing.T) {
 		t.Fatalf("got error %v, want the inner error", err)
 	}
 }
+
+func TestInsertMdReadFailureLeavesFileAlone(t *testing.T) {
+	readErr := errors.New("read failed")
+	writer := &writerSpy{}
+	backupper := &backupperSpy{}
+	uc := New(Config{}, innerStub{toc: entity.Toc{"* [A](#a)"}}, readerStub{err: readErr}, writer,
+		backupper, stamperStub{}, &notifierSpy{}, loggerStub{})
+
+	if _, err := uc.Do(context.Background(), "README.md"); !errors.Is(err, readErr) {
+		t.Fatalf("got error %v, want the read error", err)
+	}
+	if writer.got != nil {
+		t.Errorf("got a write of %q, want none", writer.got)
+	}
+	if backupper.calls != 0 {
+		t.Errorf("got %d backup calls, want none", backupper.calls)
+	}
+}
+
+func TestInsertMdBackupFailureSkipsTheWrite(t *testing.T) {
+	backupErr := errors.New("backup failed")
+	writer := &writerSpy{}
+	notify := &notifierSpy{}
+	uc := New(Config{}, innerStub{toc: entity.Toc{"* [A](#a)"}},
+		readerStub{data: []byte("<!--ts-->\n<!--te-->\n")}, writer,
+		&backupperSpy{err: backupErr}, stamperStub{}, notify, loggerStub{})
+
+	if _, err := uc.Do(context.Background(), "README.md"); !errors.Is(err, backupErr) {
+		t.Fatalf("got error %v, want the backup error", err)
+	}
+	if writer.got != nil {
+		t.Errorf("got a write of %q, want none - a failed backup must never be followed by a rewrite", writer.got)
+	}
+	if len(notify.messages) != 0 {
+		t.Errorf("got messages %v, want none - nothing succeeded", notify.messages)
+	}
+}
+
+func TestInsertMdWriteFailurePropagates(t *testing.T) {
+	writeErr := errors.New("write failed")
+	writer := &writerSpy{err: writeErr}
+	notify := &notifierSpy{}
+	uc := New(Config{NoBackup: true}, innerStub{toc: entity.Toc{"* [A](#a)"}},
+		readerStub{data: []byte("<!--ts-->\n<!--te-->\n")}, writer,
+		&backupperSpy{}, stamperStub{}, notify, loggerStub{})
+
+	if _, err := uc.Do(context.Background(), "README.md"); !errors.Is(err, writeErr) {
+		t.Fatalf("got error %v, want the write error", err)
+	}
+	if len(notify.messages) != 0 {
+		t.Errorf("got messages %v, want none - the insert notice must not claim a write that failed", notify.messages)
+	}
+}

--- a/internal/core/usecase/insertmd/insertmd_test.go
+++ b/internal/core/usecase/insertmd/insertmd_test.go
@@ -1,0 +1,149 @@
+package insertmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+)
+
+type innerStub struct {
+	toc entity.Toc
+	err error
+}
+
+func (s innerStub) Do(context.Context, string) (entity.Toc, error) { return s.toc, s.err }
+
+type readerStub struct {
+	data []byte
+	err  error
+}
+
+func (s readerStub) Read(context.Context, string) ([]byte, error) { return s.data, s.err }
+
+type writerSpy struct {
+	got []byte
+	err error
+}
+
+func (s *writerSpy) WriteAtomic(_ context.Context, _ string, data []byte) error {
+	s.got = data
+	return s.err
+}
+
+type backupperSpy struct {
+	calls int
+	err   error
+}
+
+func (s *backupperSpy) Backup(_ context.Context, file string) (string, error) {
+	s.calls++
+	return file + ".orig.2026-08-12_134506", s.err
+}
+
+type stamperStub struct{}
+
+func (stamperStub) Stamp() string { return "<!-- Added by: tester, at: 2026-08-12T13:45:06Z -->" }
+
+type notifierSpy struct{ messages []string }
+
+func (s *notifierSpy) Notify(format string, args ...any) {
+	s.messages = append(s.messages, fmt.Sprintf(format, args...))
+}
+
+type loggerStub struct{}
+
+func (loggerStub) Info(string, ...any) {}
+
+func newTestInsertMd(cfg Config, content string, toc entity.Toc) (*InsertMd, *writerSpy, *backupperSpy, *notifierSpy) {
+	writer := &writerSpy{}
+	backupper := &backupperSpy{}
+	notify := &notifierSpy{}
+	uc := New(cfg, innerStub{toc: toc}, readerStub{data: []byte(content)}, writer,
+		backupper, stamperStub{}, notify, loggerStub{})
+	return uc, writer, backupper, notify
+}
+
+func TestInsertMdWritesBlockWithFooter(t *testing.T) {
+	content := "# Title\n\n<!--ts-->\nstale\n<!--te-->\n\n## Section\n"
+	uc, writer, backupper, notify := newTestInsertMd(Config{}, content, entity.Toc{"* [Title](#title)"})
+
+	got, err := uc.Do(context.Background(), "README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "* [Title](#title)" {
+		t.Errorf("got TOC %v, want it returned unchanged", got)
+	}
+
+	want := "# Title\n\n<!--ts-->\n" +
+		"* [Title](#title)\n" +
+		"\n" +
+		"<!-- Created by https://github.com/ekalinin/github-markdown-toc.go -->\n" +
+		"<!-- Added by: tester, at: 2026-08-12T13:45:06Z -->\n" +
+		"<!--te-->\n\n## Section\n"
+	if string(writer.got) != want {
+		t.Errorf("got written file\n%q\nwant\n%q", writer.got, want)
+	}
+	if backupper.calls != 1 {
+		t.Errorf("got %d backup calls, want 1", backupper.calls)
+	}
+	if len(notify.messages) != 2 {
+		t.Errorf("got messages %v, want the backup and the insert notice", notify.messages)
+	}
+}
+
+func TestInsertMdHideFooter(t *testing.T) {
+	content := "<!--ts-->\n<!--te-->\n"
+	uc, writer, _, _ := newTestInsertMd(Config{HideFooter: true}, content, entity.Toc{"* [Title](#title)"})
+
+	if _, err := uc.Do(context.Background(), "README.md"); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(writer.got), "Added by") {
+		t.Errorf("got written file %q, want no signature comment", writer.got)
+	}
+}
+
+func TestInsertMdNoBackup(t *testing.T) {
+	content := "<!--ts-->\n<!--te-->\n"
+	uc, _, backupper, notify := newTestInsertMd(Config{NoBackup: true}, content, entity.Toc{"* [A](#a)"})
+
+	if _, err := uc.Do(context.Background(), "README.md"); err != nil {
+		t.Fatal(err)
+	}
+	if backupper.calls != 0 {
+		t.Errorf("got %d backup calls, want none", backupper.calls)
+	}
+	if len(notify.messages) != 1 {
+		t.Errorf("got messages %v, want only the insert notice", notify.messages)
+	}
+}
+
+func TestInsertMdMissingMarkersLeavesFileAlone(t *testing.T) {
+	uc, writer, backupper, _ := newTestInsertMd(Config{}, "# Title\n", entity.Toc{"* [Title](#title)"})
+
+	_, err := uc.Do(context.Background(), "README.md")
+	if !errors.Is(err, ErrMarkersNotFound) {
+		t.Fatalf("got error %v, want ErrMarkersNotFound", err)
+	}
+	if writer.got != nil {
+		t.Errorf("got a write of %q, want none", writer.got)
+	}
+	if backupper.calls != 0 {
+		t.Errorf("got %d backup calls, want none - validation runs first", backupper.calls)
+	}
+}
+
+func TestInsertMdPropagatesInnerError(t *testing.T) {
+	innerErr := errors.New("grab failed")
+	uc := New(Config{}, innerStub{err: innerErr}, readerStub{}, &writerSpy{},
+		&backupperSpy{}, stamperStub{}, &notifierSpy{}, loggerStub{})
+
+	if _, err := uc.Do(context.Background(), "README.md"); !errors.Is(err, innerErr) {
+		t.Fatalf("got error %v, want the inner error", err)
+	}
+}

--- a/internal/core/usecase/insertmd/markers.go
+++ b/internal/core/usecase/insertmd/markers.go
@@ -1,0 +1,55 @@
+package insertmd
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+)
+
+var (
+	ErrMarkersNotFound     = errors.New("no <!--ts--> / <!--te--> markers found")
+	ErrMultipleMarkerPairs = errors.New("multiple <!--ts--> / <!--te--> marker pairs found")
+	ErrMarkersOutOfOrder   = errors.New("the <!--te--> marker precedes <!--ts-->")
+)
+
+// replaceBetweenMarkers puts block between the TOC markers. The markers themselves
+// and everything around them are left byte for byte as they were, so a document with
+// CRLF endings keeps them outside the replaced block.
+func replaceBetweenMarkers(content, block []byte) ([]byte, error) {
+	lines := strings.Split(string(content), "\n")
+
+	startIdx, endIdx := -1, -1
+	starts, ends := 0, 0
+	for i, line := range lines {
+		switch strings.TrimSpace(line) {
+		case entity.MarkerStart:
+			starts++
+			if startIdx < 0 {
+				startIdx = i
+			}
+		case entity.MarkerEnd:
+			ends++
+			if endIdx < 0 {
+				endIdx = i
+			}
+		}
+	}
+
+	switch {
+	case starts == 0 || ends == 0:
+		return nil, ErrMarkersNotFound
+	case starts > 1 || ends > 1:
+		return nil, ErrMultipleMarkerPairs
+	case endIdx < startIdx:
+		return nil, ErrMarkersOutOfOrder
+	}
+
+	result := make([]string, 0, len(lines))
+	result = append(result, lines[:startIdx+1]...)
+	if len(block) > 0 {
+		result = append(result, strings.Split(string(block), "\n")...)
+	}
+	result = append(result, lines[endIdx:]...)
+	return []byte(strings.Join(result, "\n")), nil
+}

--- a/internal/core/usecase/insertmd/markers_test.go
+++ b/internal/core/usecase/insertmd/markers_test.go
@@ -1,0 +1,82 @@
+package insertmd
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestReplaceBetweenMarkers(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		block   string
+		want    string
+		wantErr error
+	}{
+		{
+			name:    "replaces an existing block",
+			content: "# Title\n\n<!--ts-->\nstale\nlines\n<!--te-->\n\n## Section\n",
+			block:   "* [Title](#title)",
+			want:    "# Title\n\n<!--ts-->\n* [Title](#title)\n<!--te-->\n\n## Section\n",
+		},
+		{
+			name:    "fills an empty block",
+			content: "<!--ts-->\n<!--te-->\n",
+			block:   "* [A](#a)\n* [B](#b)",
+			want:    "<!--ts-->\n* [A](#a)\n* [B](#b)\n<!--te-->\n",
+		},
+		{
+			name:    "keeps indented markers and their indentation",
+			content: "  <!--ts-->\nstale\n  <!--te-->\n",
+			block:   "* [A](#a)",
+			want:    "  <!--ts-->\n* [A](#a)\n  <!--te-->\n",
+		},
+		{
+			name:    "tolerates CRLF line endings",
+			content: "# Title\r\n<!--ts-->\r\nstale\r\n<!--te-->\r\n",
+			block:   "* [Title](#title)",
+			want:    "# Title\r\n<!--ts-->\r\n* [Title](#title)\n<!--te-->\r\n",
+		},
+		{
+			name:    "no markers",
+			content: "# Title\n",
+			block:   "* [Title](#title)",
+			wantErr: ErrMarkersNotFound,
+		},
+		{
+			name:    "only the start marker",
+			content: "<!--ts-->\n# Title\n",
+			block:   "* [Title](#title)",
+			wantErr: ErrMarkersNotFound,
+		},
+		{
+			name:    "two pairs",
+			content: "<!--ts-->\n<!--te-->\n<!--ts-->\n<!--te-->\n",
+			block:   "* [A](#a)",
+			wantErr: ErrMultipleMarkerPairs,
+		},
+		{
+			name:    "reversed markers",
+			content: "<!--te-->\nbody\n<!--ts-->\n",
+			block:   "* [A](#a)",
+			wantErr: ErrMarkersOutOfOrder,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := replaceBetweenMarkers([]byte(tt.content), []byte(tt.block))
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("got error %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("got\n%q\nwant\n%q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #7. Fixes #26. Supersedes #57, which targets the pre-refactor tree and no longer merges.

Stacked on #77. Review that one first.

## What changed

`--insert` rewrites the TOC in place, between a `<!--ts-->` and a `<!--te-->` marker line:

- Both markers are required, each alone on its line, exactly one pair. Anything else is an error and the file is left untouched. Markers are never created automatically.
- The block between them is replaced with the TOC, followed by an attribution comment and an `Added by: <user>, at: <date>` signature unless `--hide-footer` is given.
- A backup is left at `<file>.orig.<YYYY-MM-DD_HHMMSS>`, matching the bash suffix. `--no-backup` skips it, and requires `--insert`.
- The write is atomic (temp file plus rename) and preserves the file mode, so a failed write cannot truncate a README.

Structurally, `insertmd` is a use case wrapping `localmd`, assembled in `internal/app/new.go`. `internal/controller` is unchanged.

## Why

The last big feature the bash tool has and this port did not.

Two behaviours are worth calling out because they are deliberate:

- `remotemd` keeps the unwrapped `localmd`, so `--insert` can never rewrite the temporary file a remote document is downloaded into. This is enforced by the type system: `InsertMd` implements only `Do`, while `remotemd` requires `DoAs`.
- Marker validation runs before the backup, so a document without markers leaves nothing behind at all.

## Compatibility

`--hide-footer` gains a second meaning: without `--insert` it hides the stdout attribution line as before; with `--insert` it also suppresses the signature comment written into the file. It does not enable `--insert`.

Status messages go to stderr rather than stdout, so `gh-md-toc --insert *.md > out.md` is not corrupted by them. bash prints them to stdout.

The `Table of Contents` heading is not written into the file; bash prints it to stdout only.

## Validation

```
go test ./...
go vet ./...
make e2e   # section 5 is new and covers --insert against a fixture
```