### PR TITLE
feat(skip-header): add the --skip-header flag

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,8 +42,9 @@ cmd/gh-md-toc
         │   └── input routing, concurrency, and result output
         ├── internal/core/usecase
         │   ├── localmd
-        │   ├── insertmd (wraps localmd, only when --insert is set)
-        │   ├── remotemd
+        │   ├── skipheader (wraps localmd, only when --skip-header is set)
+        │   ├── insertmd (wraps localChain, only when --insert is set)
+        │   ├── remotemd (wraps localChain unconditionally)
         │   └── remotehtml
         ├── internal/core/toc
         │   ├── Generator
@@ -125,7 +126,15 @@ flowchart TD
     RegexpGenerator --> LocalMd
     Logger --> LocalMd
 
-    LocalMd --> InsertMd
+    LocalMd --> SkipHeader
+    FileReader --> SkipHeader
+    FileTemper --> SkipHeader
+    Logger --> SkipHeader
+
+    LocalMd -.->|"--skip-header not set"| LocalChain[localChain]
+    SkipHeader -.->|"--skip-header set"| LocalChain
+
+    LocalChain --> InsertMd
     FileReader --> InsertMd
     FileWriter --> InsertMd
     FileBackupper --> InsertMd
@@ -135,7 +144,7 @@ flowchart TD
 
     RemoteGetter --> RemoteMd
     FileTemper --> RemoteMd
-    LocalMd --> RemoteMd
+    LocalChain --> RemoteMd
     Logger --> RemoteMd
 
     RemoteGetter --> RemoteHTML
@@ -143,7 +152,7 @@ flowchart TD
     JSONGenerator --> RemoteHTML
     Logger --> RemoteHTML
 
-    LocalMd -.->|"--insert not set"| Controller
+    LocalChain -.->|"--insert not set"| Controller
     InsertMd -.->|"--insert set"| Controller
     RemoteMd --> Controller
     RemoteHTML --> Controller
@@ -153,12 +162,19 @@ flowchart TD
 
 The shared `http.Client` gives all remote operations the same timeout configuration. The shared `Renderer` gives both extraction paths the same TOC formatting behavior.
 
-`InsertMd` wraps `LocalMd`, it does not replace it: `app.New` always builds the plain
-`LocalMd` and only builds `InsertMd` around it when `cfg.Insert.Enabled` is true. The
-controller then receives whichever of the two implements the local-file use case for
-that run. `RemoteMd` always keeps a direct reference to the unwrapped `LocalMd`,
-never to `InsertMd`, because it processes a downloaded temporary file and must never
-have a TOC written back into it.
+`app.New` always builds the plain `LocalMd`. When `cfg.SkipHeader` is true, it wraps
+`LocalMd` in `SkipHeader`; either way, the result is assigned to the local variable
+`localChain`. `LocalMd` and `SkipHeader` both satisfy the `markdownProcessor`
+interface (`Do` and `DoAs`), so every consumer further down the chain works with
+`localChain` without caring which of the two it actually holds.
+
+`InsertMd` wraps `localChain`, it does not replace it: `app.New` only builds
+`InsertMd` around `localChain` when `cfg.Insert.Enabled` is true. The controller then
+receives whichever of the two implements the local-file use case for that run.
+`RemoteMd` always keeps a direct reference to `localChain`, never to `InsertMd`,
+because it processes a downloaded temporary file and must never have a TOC written
+back into it. `--skip-header` still applies to `RemoteMd`'s downloaded document
+through `localChain`; only the temp-file-into-`InsertMd` combination is disallowed.
 
 ## Main types and responsibilities
 
@@ -171,8 +187,9 @@ have a TOC written back into it.
 | `internal/app` | `InsertConfig` | Controls whether the TOC is written into the source document and whether a backup is kept. |
 | `internal/controller` | `Controller` | Selects a use case, runs document jobs, preserves output order, and aggregates errors. |
 | `internal/core/usecase/localmd` | `LocalMd` | Validates a local file, converts Markdown through GitHub, and generates a TOC from returned HTML. |
-| `internal/core/usecase/insertmd` | `InsertMd` | Wraps `LocalMd`, then backs up and rewrites the block between the TOC markers in the source file. |
-| `internal/core/usecase/remotemd` | `RemoteMd` | Downloads raw Markdown to a temporary file and delegates processing to `LocalMd`. |
+| `internal/core/usecase/skipheader` | `SkipHeader` | Wraps `LocalMd` (or another `markdownProcessor`), cutting everything up to and including `<!--te-->` into a temporary file before delegating. |
+| `internal/core/usecase/insertmd` | `InsertMd` | Wraps `localChain` (`LocalMd`, optionally wrapped by `SkipHeader`), then backs up and rewrites the block between the TOC markers in the source file. |
+| `internal/core/usecase/remotemd` | `RemoteMd` | Downloads raw Markdown to a temporary file and delegates processing to `localChain`. |
 | `internal/core/usecase/remotehtml` | `RemoteHTML` | Downloads GitHub JSON data and generates a TOC through the JSON path. |
 | `internal/core/toc` | `Generator` | Combines a heading extractor with the shared renderer. |
 | `internal/core/toc` | `Renderer` | Applies depth, indentation, escaping, and link rules to headings. |
@@ -201,16 +218,21 @@ Interfaces are intentionally small and located next to the consuming code.
 | Consumer | Interface | Implemented by |
 |---|---|---|
 | `app.App` | `app.Controller` | `*controller.Controller` |
-| `app.App` | `app.useCase` (used by `app.New`, not stored on `App`) | `*localmd.LocalMd`, `*insertmd.InsertMd` |
+| `app.App` | `app.useCase` (used by `app.New`, not stored on `App`) | `*localmd.LocalMd`, `*skipheader.SkipHeader`, `*insertmd.InsertMd` |
+| `app.App` | `app.markdownProcessor` (used by `app.New` to type `localChain`) | `*localmd.LocalMd`, `*skipheader.SkipHeader` |
 | `app.App` | `app.notifier` | `*adapters.Notifier` |
-| `controller.Controller` | `controller.useCase` | `*localmd.LocalMd`, `*insertmd.InsertMd`, `*remotemd.RemoteMd`, `*remotehtml.RemoteHTML` |
+| `controller.Controller` | `controller.useCase` | `*localmd.LocalMd`, `*skipheader.SkipHeader`, `*insertmd.InsertMd`, `*remotemd.RemoteMd`, `*remotehtml.RemoteHTML` |
 | `controller.Controller` | `controller.logger` | `*adapters.Logger` |
 | `localmd.LocalMd` | `localmd.fileChecker` | `*adapters.FileChecker` |
 | `localmd.LocalMd` | `localmd.fileWriter` | `*adapters.FileWriter` |
 | `localmd.LocalMd` | `localmd.htmlConverter` | `*adapters.HTMLConverter` |
 | `localmd.LocalMd` | `localmd.tocGrabber` | `*toc.Generator` |
 | `localmd.LocalMd` | `localmd.logger` | `*adapters.Logger` |
-| `insertmd.InsertMd` | `insertmd.useCase` | `*localmd.LocalMd` |
+| `skipheader.SkipHeader` | `skipheader.markdownProcessor` | `*localmd.LocalMd` |
+| `skipheader.SkipHeader` | `skipheader.fileReader` | `*adapters.FileReader` |
+| `skipheader.SkipHeader` | `skipheader.fileTemper` | `*adapters.FileTemper` |
+| `skipheader.SkipHeader` | `skipheader.logger` | `*adapters.Logger` |
+| `insertmd.InsertMd` | `insertmd.useCase` | `*localmd.LocalMd`, `*skipheader.SkipHeader` (whichever `localChain` holds) |
 | `insertmd.InsertMd` | `insertmd.fileReader` | `*adapters.FileReader` |
 | `insertmd.InsertMd` | `insertmd.atomicWriter` | `*adapters.FileWriter` |
 | `insertmd.InsertMd` | `insertmd.fileBackupper` | `*adapters.FileBackupper` |
@@ -218,7 +240,7 @@ Interfaces are intentionally small and located next to the consuming code.
 | `insertmd.InsertMd` | `insertmd.notifier` | `*adapters.Notifier` |
 | `insertmd.InsertMd` | `insertmd.logger` | `*adapters.Logger` |
 | `remotemd.RemoteMd` | `remotemd.remoteGetter` | `*adapters.RemoteGetter` |
-| `remotemd.RemoteMd` | `remotemd.markdownProcessor` | `*localmd.LocalMd` (always the unwrapped use case, never `*insertmd.InsertMd`) |
+| `remotemd.RemoteMd` | `remotemd.markdownProcessor` | `*localmd.LocalMd` or `*skipheader.SkipHeader` (always `localChain`, never `*insertmd.InsertMd`) |
 | `remotemd.RemoteMd` | `remotemd.fileTemper` | `*adapters.FileTemper` |
 | `remotemd.RemoteMd` | `remotemd.logger` | `*adapters.Logger` |
 | `remotehtml.RemoteHTML` | `remotehtml.remoteGetter` | `*adapters.RemoteGetter` |
@@ -236,6 +258,7 @@ These interfaces allow unit tests to replace each dependency with a small stub w
 app.Config
 ├── Files []string
 ├── Serial bool
+├── SkipHeader bool
 ├── Debug bool
 ├── Presentation app.PresentationConfig
 │   ├── HideHeader bool
@@ -257,11 +280,16 @@ app.Config
 
 `cmd/gh-md-toc` maps flags and environment variables into this structure. `app.New` derives `TOC.AbsolutePaths` from whether the CLI received multiple file arguments, matching bash `gh-md-toc`, which drops the prefix when a single document is requested.
 
+`SkipHeader` selects whether `app.New` wraps `LocalMd` in `SkipHeader` before
+assigning the result to `localChain`; it takes no other parameters, since the
+`<!--te-->` marker itself is the only input the use case needs.
+
 Only the settings required at runtime are passed further:
 
 - controller receives `Files` and `Serial`;
 - `LocalMd` and `RemoteHTML` receive `Debug`;
-- `RemoteMd` receives no configuration;
+- `SkipHeader` and `RemoteMd` receive no configuration beyond the collaborators they
+  are built with;
 - `Renderer` receives `toc.Config`;
 - GitHub settings are used when constructing `HTMLConverter` and `RegexpExtractor`;
 - `InsertMd` receives `Insert.NoBackup` and `Presentation.HideFooter`; `app.Run` reads
@@ -297,12 +325,41 @@ Controller
 
 When debug mode is enabled, `LocalMd` writes the returned HTML to `<input>.debug.html` through `FileWriter`.
 
+### Skip header (`--skip-header`)
+
+```text
+Controller (or InsertMd, if --insert is also set)
+  -> SkipHeader.Do / DoAs
+  -> FileReader.Read
+  -> trim everything up to and including <!--te-->
+  -> FileTemper.CreateTemp
+  -> write the trimmed copy
+  -> LocalMd.DoAs (builds the TOC from the trimmed copy, as above)
+  -> FileTemper.Remove
+  -> entity.Toc
+```
+
+`SkipHeader` wraps `LocalMd` rather than replacing it: it reads the source file,
+drops every line up to and including the `<!--te-->` marker, and writes what remains
+to a temporary file. It then delegates to `LocalMd.DoAs` with the temporary file as
+the path to read and the *original* file as the display path, so rendered links still
+point at the source document. If the source file has no `<!--te-->` marker, `SkipHeader`
+skips the trimming and delegates to the inner use case with the original file
+unchanged. The temporary file is always removed afterward, whether or not the inner
+call succeeded.
+
+`app.New` only builds `SkipHeader` when `cfg.SkipHeader` is true; otherwise
+`localChain` is the plain `LocalMd`. Because `SkipHeader` implements the same
+`markdownProcessor` interface as `LocalMd` (`Do` and `DoAs`), every consumer that
+holds `localChain` - `InsertMd` and `RemoteMd` - works identically regardless of
+which one it is.
+
 ### Insert into the source file (`--insert`)
 
 ```text
 Controller
   -> InsertMd.Do
-  -> LocalMd.Do (builds the TOC, as above)
+  -> localChain.Do (builds the TOC; may go through SkipHeader first, as above)
   -> FileReader.Read
   -> replaceBetweenMarkers (validate and rewrite the <!--ts--> / <!--te--> block)
   -> FileBackupper.Backup      (skipped when --no-backup is set)
@@ -311,23 +368,27 @@ Controller
   -> entity.Toc
 ```
 
-`InsertMd` wraps `LocalMd` rather than replacing it: it delegates to `LocalMd.Do` to
-obtain the TOC, then reads the current file, validates that it has exactly one
-`<!--ts-->` / `<!--te-->` marker pair in order, and rewrites only the block between
-them, byte for byte outside that block. The backup step runs before the rewrite so a
-failed rewrite still leaves a pristine copy on disk; it is skipped when
-`Insert.NoBackup` is set. `FileWriter.WriteAtomic` writes through a temporary file in
-the same directory and renames it over the target, so a failed write cannot truncate
-the original. `Notifier` reports the backup path and the rewritten path on stderr,
-separate from the TOC printed to stdout.
+`InsertMd` wraps `localChain` rather than replacing it: it delegates to
+`localChain.Do` to obtain the TOC, then reads the *current, untrimmed* file,
+validates that it has exactly one `<!--ts-->` / `<!--te-->` marker pair in order, and
+rewrites only the block between them, byte for byte outside that block. This is what
+makes `--insert --skip-header` correct together: the TOC is built from the content
+after the existing block (because `localChain` trimmed it away before building the
+TOC), while the rewrite step still sees, and correctly replaces, the existing block
+in the real file. The backup step runs before the rewrite so a failed rewrite still
+leaves a pristine copy on disk; it is skipped when `Insert.NoBackup` is set.
+`FileWriter.WriteAtomic` writes through a temporary file in the same directory and
+renames it over the target, so a failed write cannot truncate the original.
+`Notifier` reports the backup path and the rewritten path on stderr, separate from
+the TOC printed to stdout.
 
 `app.New` only builds `InsertMd` when `cfg.Insert.Enabled` is true; otherwise the
-controller receives the plain `LocalMd` for local files, unchanged from before this
-use case existed. `RemoteMd` is wired with the unwrapped `LocalMd` unconditionally, so
-downloading a remote document and then applying `--insert` to it never happens - the
-temporary file `RemoteMd` creates cannot be the target of a rewrite. `app.Run` warns
-on stderr, once per input, about any file passed alongside `--insert` that is not
-`entity.TypeLocalMD`, and otherwise leaves the document unmodified.
+controller receives the plain `localChain` for local files, unchanged from before
+`InsertMd` existed. `RemoteMd` is wired with `localChain` unconditionally, never with
+`InsertMd`, so downloading a remote document and then applying `--insert` to it never
+happens - the temporary file `RemoteMd` creates cannot be the target of a rewrite.
+`app.Run` warns on stderr, once per input, about any file passed alongside `--insert`
+that is not `entity.TypeLocalMD`, and otherwise leaves the document unmodified.
 
 ### Remote raw Markdown
 
@@ -337,12 +398,12 @@ Controller
   -> RemoteGetter.Get
   -> FileTemper.CreateTemp
   -> write downloaded Markdown
-  -> LocalMd.DoAs
+  -> localChain.DoAs
   -> remove temporary file
   -> entity.Toc
 ```
 
-`RemoteMd` reuses the complete local Markdown workflow after downloading the document. It validates the response media type as `text/plain` before creating the temporary file. It calls `LocalMd.DoAs` with the temporary file path and the original URL as the display path, so rendered links point at the source document instead of the temporary file.
+`RemoteMd` reuses the complete local Markdown workflow after downloading the document. It validates the response media type as `text/plain` before creating the temporary file. It calls `localChain.DoAs` with the temporary file path and the original URL as the display path, so rendered links point at the source document instead of the temporary file. When `--skip-header` is set, `localChain` is `SkipHeader`, so the downloaded document is trimmed the same way a local file would be - skipping a header in a downloaded document is correct, since the document itself is never rewritten.
 
 ### GitHub document page
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ CLI behaviour, not about the output format.
 
 ### Fixed
 
+- `--debug` writes its HTML dump next to the document you named. With `--skip-header`
+  the dump used to be named after an internal temporary copy and was left behind in
+  the temp directory.
 - `GH_TOC_URL` is honoured again when `--github-url` is not passed. The flag's non-empty
   default used to shadow the environment variable, so the variable had no effect.
   ([#60](https://github.com/ekalinin/github-markdown-toc.go/pull/60))

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Table of Contents
     * [Multiple files](#multiple-files)
     * [Combo](#combo)
     * [Insert into a file](#insert-into-a-file)
+    * [Skip header](#skip-header)
     * [Starting Depth](#starting-depth)
     * [Depth](#depth)
     * [No Escape](#no-escape)
@@ -104,6 +105,7 @@ Flags:
                    RegExp version. Default: 2024-03
   --insert         Insert the TOC into the file, between <!--ts--> and <!--te-->. Local files only
   --no-backup      Do not keep a backup copy of the file. Requires --insert
+  --skip-header    Ignore everything up to <!--te--> when building the TOC
   --version        Show application version.
 
 Args:
@@ -340,6 +342,27 @@ ran the command, and when) are written right after the TOC, inside the markers.
 
 Status messages - the backup path, or a warning about a non-local input - are
 printed to stderr, not stdout.
+
+Skip header
+-----------
+
+Use `--skip-header` to make `gh-md-toc` ignore everything up to and including the
+end marker (`<!--te-->`) when building the TOC. Only the content after that marker
+is scanned for headings.
+
+```bash
+$ ./gh-md-toc --skip-header README.md
+```
+
+This matters when combined with `--insert`: after a first `--insert` run, the file
+already has a TOC block written between the markers. Re-running `--insert` without
+`--skip-header` scans that block, and anything above it, together with the rest of
+the document. Adding `--skip-header` makes sure only the content after the existing
+block feeds the new TOC, so re-running `--insert` repeatedly does not fold the old
+TOC's own entries back into itself.
+
+`--skip-header` has no effect on documents that don't contain an end marker; the
+whole document is scanned, exactly as without the flag.
 
 Starting Depth
 --------------

--- a/README.md
+++ b/README.md
@@ -354,12 +354,15 @@ is scanned for headings.
 $ ./gh-md-toc --skip-header README.md
 ```
 
-This matters when combined with `--insert`: after a first `--insert` run, the file
-already has a TOC block written between the markers. Re-running `--insert` without
-`--skip-header` scans that block, and anything above it, together with the rest of
-the document. Adding `--skip-header` makes sure only the content after the existing
-block feeds the new TOC, so re-running `--insert` repeatedly does not fold the old
-TOC's own entries back into itself.
+The point is to hide the topmost headlines - the document's own title, and any
+other heading placed above the marker block, are excluded from the generated TOC.
+Without `--skip-header`, a document's title heading gets picked up like any other
+heading and shows up as an entry in its own TOC.
+
+This matters when combined with `--insert`: place the markers right below your
+title, e.g. `# Project` followed by `<!--ts-->`/`<!--te-->`, and add `--skip-header`
+to keep `Project` from appearing as the first entry of the TOC sitting right under
+it.
 
 `--skip-header` has no effect on documents that don't contain an end marker; the
 whole document is scanned, exactly as without the flag.

--- a/cmd/gh-md-toc/config.go
+++ b/cmd/gh-md-toc/config.go
@@ -31,6 +31,7 @@ type cliOptions struct {
 	reVersion  *string
 	insert     *bool
 	noBackup   *bool
+	skipHeader *bool
 }
 
 func newCLI() (*kingpin.Application, cliOptions) {
@@ -64,6 +65,10 @@ func newCLI() (*kingpin.Application, cliOptions) {
 		noBackup: parser.Flag(
 			"no-backup",
 			"Do not keep a backup copy of the file. Requires --insert",
+		).Bool(),
+		skipHeader: parser.Flag(
+			"skip-header",
+			"Ignore everything up to <!--te--> when building the TOC",
 		).Bool(),
 	}
 
@@ -106,8 +111,9 @@ func parseConfig(args []string) (app.Config, error) {
 	}
 
 	return app.Config{
-		Files:  files,
-		Serial: *options.serial,
+		Files:      files,
+		Serial:     *options.serial,
+		SkipHeader: *options.skipHeader,
 		Presentation: app.PresentationConfig{
 			HideHeader: *options.hideHeader,
 			HideFooter: *options.hideFooter,

--- a/e2e-tests/want.md
+++ b/e2e-tests/want.md
@@ -17,6 +17,7 @@ Table of Contents
   * [Multiple files](#multiple-files)
   * [Combo](#combo)
   * [Insert into a file](#insert-into-a-file)
+  * [Skip header](#skip-header)
   * [Starting Depth](#starting-depth)
   * [Depth](#depth)
   * [No escape](#no-escape)

--- a/e2e-tests/want3.md
+++ b/e2e-tests/want3.md
@@ -13,6 +13,7 @@
     * [Multiple files](#multiple-files)
     * [Combo](#combo)
     * [Insert into a file](#insert-into-a-file)
+    * [Skip header](#skip-header)
     * [Starting Depth](#starting-depth)
     * [Depth](#depth)
     * [No escape](#no-escape)

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -6,6 +6,7 @@ import coretoc "github.com/ekalinin/github-markdown-toc.go/v2/internal/core/toc"
 type Config struct {
 	Files        []string
 	Serial       bool
+	SkipHeader   bool
 	Presentation PresentationConfig
 	GitHub       GitHubConfig
 	TOC          coretoc.Config

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/localmd"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/remotehtml"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/remotemd"
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/usecase/skipheader"
 )
 
 type Controller interface {
@@ -21,6 +22,13 @@ type Controller interface {
 
 type useCase interface {
 	Do(ctx context.Context, file string) (entity.Toc, error)
+}
+
+// markdownProcessor is the local-document pipeline: the plain use case, or one
+// wrapped by skipheader. Both forms carry the display path through DoAs.
+type markdownProcessor interface {
+	Do(ctx context.Context, file string) (entity.Toc, error)
+	DoAs(ctx context.Context, file, displayPath string) (entity.Toc, error)
 }
 
 type notifier interface {
@@ -51,6 +59,7 @@ func New(cfg Config, stderr io.Writer) (*App, error) {
 		"token-configured", cfg.GitHub.GHToken != "",
 		"insert", cfg.Insert.Enabled,
 		"no-backup", cfg.Insert.NoBackup,
+		"skip-header", cfg.SkipHeader,
 	)
 	ctlCfg := controller.Config{Files: cfg.Files, Serial: cfg.Serial}
 
@@ -84,20 +93,23 @@ func New(cfg Config, stderr io.Writer) (*App, error) {
 	stamper := adapters.NewStamper()
 
 	log.Info("App.New: init usecases ...")
-	ucLocalMD := localmd.New(cfg.Debug, checker, writer, converter, grabberRe, log)
+	var localChain markdownProcessor = localmd.New(cfg.Debug, checker, writer, converter, grabberRe, log)
+	if cfg.SkipHeader {
+		localChain = skipheader.New(localChain, reader, temper, log)
+	}
 
-	var ucLocal useCase = ucLocalMD
+	var ucLocal useCase = localChain
 	if cfg.Insert.Enabled {
 		ucLocal = insertmd.New(
 			insertmd.Config{
 				NoBackup:   cfg.Insert.NoBackup,
 				HideFooter: cfg.Presentation.HideFooter,
 			},
-			ucLocalMD, reader, writer, backupper, stamper, notify, log,
+			localChain, reader, writer, backupper, stamper, notify, log,
 		)
 	}
 
-	ucRemoteMD := remotemd.New(getter, ucLocalMD, temper, log)
+	ucRemoteMD := remotemd.New(getter, localChain, temper, log)
 	ucRemoteHTML := remotehtml.New(cfg.Debug, getter, temper, grabberJSON, log)
 
 	log.Info("App.New: init controller ...")

--- a/internal/app/new_test.go
+++ b/internal/app/new_test.go
@@ -2,11 +2,17 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	coretoc "github.com/ekalinin/github-markdown-toc.go/v2/internal/core/toc"
 	"github.com/ekalinin/github-markdown-toc.go/v2/internal/version"
 )
 
@@ -49,5 +55,83 @@ func TestNewRejectsUnknownRegexpVersion(t *testing.T) {
 	want := "initialize regexp grabber: unsupported GitHub regexp version \"unknown\""
 	if !strings.Contains(err.Error(), want) {
 		t.Errorf("got error %q, want it to contain %q", err, want)
+	}
+}
+
+func TestNewSkipHeaderTrimsTheDocumentSentToGitHub(t *testing.T) {
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<h2 class="heading-element">Section</h2>`))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "README.md")
+	content := "# Old Title\n<!--ts-->\n* [Old Title](#old-title)\n<!--te-->\n\n## Section\n"
+	if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	application, err := New(Config{
+		Files:      []string{file},
+		SkipHeader: true,
+		GitHub:     GitHubConfig{GHUrl: server.URL, GHVersion: version.GH_2024_03},
+		TOC:        coretoc.DefaultConfig(),
+	}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.Run(context.Background(), &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(gotBody, "Old Title") {
+		t.Errorf("got request body %q, want everything up to <!--te--> dropped", gotBody)
+	}
+	if !strings.Contains(gotBody, "## Section") {
+		t.Errorf("got request body %q, want the content after <!--te--> kept", gotBody)
+	}
+}
+
+func TestNewWithoutSkipHeaderSendsTheWholeDocument(t *testing.T) {
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<h2 class="heading-element">Section</h2>`))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "README.md")
+	content := "# Old Title\n<!--ts-->\n* [Old Title](#old-title)\n<!--te-->\n\n## Section\n"
+	if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	application, err := New(Config{
+		Files:  []string{file},
+		GitHub: GitHubConfig{GHUrl: server.URL, GHVersion: version.GH_2024_03},
+		TOC:    coretoc.DefaultConfig(),
+	}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.Run(context.Background(), &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(gotBody, "Old Title") {
+		t.Errorf("got request body %q, want the untouched document", gotBody)
 	}
 }

--- a/internal/core/usecase/localmd/localmd.go
+++ b/internal/core/usecase/localmd/localmd.go
@@ -83,7 +83,14 @@ func (uc *LocalMd) DoAs(ctx context.Context, file, displayPath string) (entity.T
 	}
 
 	if uc.debug {
-		htmlFile := file + ".debug.html"
+		// Name the dump after the document the user asked for. When the two differ,
+		// file is a temporary copy that its owner deletes, so a dump named after it
+		// would be stranded in the temp directory instead of next to the document.
+		debugTarget := file
+		if entity.GetType(displayPath) == entity.TypeLocalMD {
+			debugTarget = displayPath
+		}
+		htmlFile := debugTarget + ".debug.html"
 		uc.log.Info("LocalMD: writing html", "file", htmlFile)
 		// TODO: move to port
 		if err := uc.writer.Write(ctx, htmlFile, []byte(html)); err != nil {

--- a/internal/core/usecase/localmd/localmd_test.go
+++ b/internal/core/usecase/localmd/localmd_test.go
@@ -205,3 +205,35 @@ func TestLocalMdDoAsUsesDisplayPath(t *testing.T) {
 		t.Errorf("got grabber path %q, want the display path", grabber.gotPath)
 	}
 }
+
+func TestLocalMdDoAsWritesDebugNextToTheDisplayPath(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "README.md")
+	trimmed := filepath.Join(dir, "ghtoc-skip-header-123.md")
+	for _, path := range []string{source, trimmed} {
+		if err := os.WriteFile(path, []byte("# Title\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	uc := New(true, checkerStub{exists: true}, &adapterWriter{},
+		converterStub{html: "<h1>Title</h1>"}, &grabberStub{toc: &entity.Toc{}}, loggerStub{})
+
+	if _, err := uc.DoAs(context.Background(), trimmed, source); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(source + ".debug.html"); err != nil {
+		t.Errorf("got no dump next to the document: %v", err)
+	}
+	if _, err := os.Stat(trimmed + ".debug.html"); !os.IsNotExist(err) {
+		t.Error("got a dump named after the temporary copy, want none")
+	}
+}
+
+// adapterWriter writes through to disk so the test can assert on real files.
+type adapterWriter struct{}
+
+func (adapterWriter) Write(_ context.Context, file string, data []byte) error {
+	return os.WriteFile(file, data, 0644)
+}

--- a/internal/core/usecase/skipheader/skipheader.go
+++ b/internal/core/usecase/skipheader/skipheader.go
@@ -1,0 +1,100 @@
+package skipheader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+)
+
+type markdownProcessor interface {
+	DoAs(context.Context, string, string) (entity.Toc, error)
+}
+
+type fileReader interface {
+	Read(context.Context, string) ([]byte, error)
+}
+
+type fileTemper interface {
+	CreateTemp(context.Context, string, string) (*os.File, error)
+	Remove(string) error
+}
+
+type logger interface {
+	Info(string, ...any)
+}
+
+// - cut everything up to and including <!--te-->
+// - hand the trimmed copy to the inner use case, keeping the original display path
+type SkipHeader struct {
+	inner  markdownProcessor
+	reader fileReader
+	temper fileTemper
+	log    logger
+}
+
+func New(inner markdownProcessor, reader fileReader, temper fileTemper, log logger) *SkipHeader {
+	return &SkipHeader{inner: inner, reader: reader, temper: temper, log: log}
+}
+
+// trimToEndMarker drops every line up to and including the <!--te--> marker. The
+// second result reports whether the marker was there at all.
+func trimToEndMarker(content []byte) ([]byte, bool) {
+	lines := strings.Split(string(content), "\n")
+	for i, line := range lines {
+		if strings.TrimSpace(line) == entity.MarkerEnd {
+			return []byte(strings.Join(lines[i+1:], "\n")), true
+		}
+	}
+	return nil, false
+}
+
+func (uc *SkipHeader) Do(ctx context.Context, file string) (entity.Toc, error) {
+	return uc.DoAs(ctx, file, file)
+}
+
+func (uc *SkipHeader) DoAs(ctx context.Context, file, displayPath string) (toc entity.Toc, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("skip header of %q: %w", file, err)
+	}
+
+	content, err := uc.reader.Read(ctx, file)
+	if err != nil {
+		return nil, fmt.Errorf("read %q to skip its header: %w", file, err)
+	}
+
+	trimmed, found := trimToEndMarker(content)
+	if !found {
+		uc.log.Info("SkipHeader: no end marker, using the file as is", "file", file)
+		return uc.inner.DoAs(ctx, file, displayPath)
+	}
+
+	tmpfile, err := uc.temper.CreateTemp(ctx, "", "ghtoc-skip-header-*.md")
+	if err != nil {
+		return nil, fmt.Errorf("create temporary file for %q: %w", file, err)
+	}
+	tempPath := tmpfile.Name()
+	defer func() {
+		if removeErr := uc.temper.Remove(tempPath); removeErr != nil {
+			err = errors.Join(err, fmt.Errorf("remove temporary file for %q: %w", file, removeErr))
+		}
+	}()
+
+	written, writeErr := tmpfile.Write(trimmed)
+	closeErr := tmpfile.Close()
+	switch {
+	case writeErr != nil:
+		return nil, fmt.Errorf("write temporary file for %q: %w", file, writeErr)
+	case written != len(trimmed):
+		return nil, fmt.Errorf("write temporary file for %q: %w", file, io.ErrShortWrite)
+	case closeErr != nil:
+		return nil, fmt.Errorf("close temporary file for %q: %w", file, closeErr)
+	}
+
+	uc.log.Info("SkipHeader: using the trimmed copy", "path", tempPath)
+	return uc.inner.DoAs(ctx, tempPath, displayPath)
+}

--- a/internal/core/usecase/skipheader/skipheader_test.go
+++ b/internal/core/usecase/skipheader/skipheader_test.go
@@ -2,6 +2,7 @@ package skipheader
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -109,5 +110,68 @@ func TestSkipHeaderWithoutMarkerUsesTheFileAsIs(t *testing.T) {
 	}
 	if inner.gotDisplayPath != "https://example.com/README.md" {
 		t.Errorf("got display path %q, want it forwarded unchanged", inner.gotDisplayPath)
+	}
+}
+
+// failingRemoveTemper hands out real temp files but cannot remove them.
+type failingRemoveTemper struct{ err error }
+
+func (t failingRemoveTemper) CreateTemp(_ context.Context, dir, pattern string) (*os.File, error) {
+	return os.CreateTemp(dir, pattern)
+}
+
+func (t failingRemoveTemper) Remove(string) error { return t.err }
+
+func TestSkipHeaderReportsCleanupFailure(t *testing.T) {
+	removeErr := errors.New("remove failed")
+	inner := &innerSpy{}
+	uc := New(inner, readerStub{data: []byte("# Title\n<!--te-->\n\n## Section\n")},
+		failingRemoveTemper{err: removeErr}, loggerStub{})
+
+	_, err := uc.Do(context.Background(), "README.md")
+	if inner.gotFile != "" {
+		t.Cleanup(func() { _ = os.Remove(inner.gotFile) })
+	}
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("got error %v, want it to carry the removal failure", err)
+	}
+	if inner.gotContent != "\n## Section\n" {
+		t.Errorf("got inner content %q, want the trimmed document - the inner call still ran", inner.gotContent)
+	}
+}
+
+// closedFileTemper returns a temp file that is already closed, so writing to it fails.
+type closedFileTemper struct{ removed *bool }
+
+func (t closedFileTemper) CreateTemp(_ context.Context, dir, pattern string) (*os.File, error) {
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Close(); err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (t closedFileTemper) Remove(path string) error {
+	*t.removed = true
+	return os.Remove(path)
+}
+
+func TestSkipHeaderRemovesTempFileWhenTheWriteFails(t *testing.T) {
+	removed := false
+	inner := &innerSpy{}
+	uc := New(inner, readerStub{data: []byte("# Title\n<!--te-->\n## Section\n")},
+		closedFileTemper{removed: &removed}, loggerStub{})
+
+	if _, err := uc.Do(context.Background(), "README.md"); err == nil {
+		t.Fatal("got no error, want the write to an already-closed file to fail")
+	}
+	if !removed {
+		t.Error("got no removal, want the temp file cleaned up after the write failed")
+	}
+	if inner.gotFile != "" {
+		t.Errorf("got the inner use case called with %q, want it never reached", inner.gotFile)
 	}
 }

--- a/internal/core/usecase/skipheader/skipheader_test.go
+++ b/internal/core/usecase/skipheader/skipheader_test.go
@@ -1,0 +1,113 @@
+package skipheader
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/ekalinin/github-markdown-toc.go/v2/internal/core/entity"
+)
+
+type innerSpy struct {
+	gotFile        string
+	gotDisplayPath string
+	gotContent     string
+}
+
+func (s *innerSpy) DoAs(_ context.Context, file, displayPath string) (entity.Toc, error) {
+	s.gotFile = file
+	s.gotDisplayPath = displayPath
+	if data, err := os.ReadFile(file); err == nil {
+		s.gotContent = string(data)
+	}
+	return entity.Toc{"* [Section](#section)"}, nil
+}
+
+type readerStub struct{ data []byte }
+
+func (s readerStub) Read(context.Context, string) ([]byte, error) { return s.data, nil }
+
+// temperStub keeps this core test free of the adapters package.
+type temperStub struct{}
+
+func (temperStub) CreateTemp(_ context.Context, dir, pattern string) (*os.File, error) {
+	return os.CreateTemp(dir, pattern)
+}
+
+func (temperStub) Remove(path string) error { return os.Remove(path) }
+
+type loggerStub struct{}
+
+func (loggerStub) Info(string, ...any) {}
+
+func TestTrimToEndMarker(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		found   bool
+	}{
+		{
+			name:    "drops the existing TOC block",
+			content: "# Title\n<!--ts-->\n* [Title](#title)\n<!--te-->\n\n## Section\n",
+			want:    "\n## Section\n",
+			found:   true,
+		},
+		{
+			name:    "tolerates indentation",
+			content: "  <!--te-->\n## Section\n",
+			want:    "## Section\n",
+			found:   true,
+		},
+		{
+			name:    "no marker",
+			content: "# Title\n## Section\n",
+			found:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := trimToEndMarker([]byte(tt.content))
+			if found != tt.found {
+				t.Fatalf("got found=%v, want %v", found, tt.found)
+			}
+			if found && string(got) != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSkipHeaderPassesTrimmedCopyDown(t *testing.T) {
+	content := "# Title\n<!--ts-->\n* [Title](#title)\n<!--te-->\n\n## Section\n"
+	inner := &innerSpy{}
+	uc := New(inner, readerStub{data: []byte(content)}, temperStub{}, loggerStub{})
+
+	if _, err := uc.Do(context.Background(), "README.md"); err != nil {
+		t.Fatal(err)
+	}
+	if inner.gotContent != "\n## Section\n" {
+		t.Errorf("got inner content %q, want the trimmed document", inner.gotContent)
+	}
+	if inner.gotDisplayPath != "README.md" {
+		t.Errorf("got display path %q, want the original file", inner.gotDisplayPath)
+	}
+	if _, err := os.Stat(inner.gotFile); !os.IsNotExist(err) {
+		t.Errorf("got temporary file %q still on disk, want it removed", inner.gotFile)
+	}
+}
+
+func TestSkipHeaderWithoutMarkerUsesTheFileAsIs(t *testing.T) {
+	inner := &innerSpy{}
+	uc := New(inner, readerStub{data: []byte("# Title\n")}, temperStub{}, loggerStub{})
+
+	if _, err := uc.DoAs(context.Background(), "README.md", "https://example.com/README.md"); err != nil {
+		t.Fatal(err)
+	}
+	if inner.gotFile != "README.md" {
+		t.Errorf("got inner file %q, want the original path", inner.gotFile)
+	}
+	if inner.gotDisplayPath != "https://example.com/README.md" {
+		t.Errorf("got display path %q, want it forwarded unchanged", inner.gotDisplayPath)
+	}
+}


### PR DESCRIPTION
Stacked on #78. Review that one first.

## What changed

`--skip-header` ignores everything up to and including the `<!--te-->` line when building the TOC. Only the content after the marker block is scanned for headings. Documents without an end marker are unaffected.

Implemented as a `skipheader` use case that trims into a temporary file and hands it to `localmd`, forwarding the caller's display path so links never point at the temp file. The chain is `insertmd( skipheader( localmd ) )`.

## Why

bash calls this "hide entry of the topmost headlines": it keeps a document's own title out of its own TOC. This repository is the canonical case - its README has a `Table of Contents` setext heading, which is an `<h1>`, so it currently lists itself.

Combined with `--insert`, the TOC is built from the content after the existing block and the block itself is then rewritten.

Note what this is *not* for: an existing TOC is a bullet list rendering as `<li>`, and the extractors match only `<h1>`-`<h6>`, so old entries can never be folded back in with or without the flag.

## Compatibility

Additive, opt-in.

## Validation

```
go test ./...
go vet ./...
```

`internal/app/new_test.go` asserts on the request body reaching the GitHub endpoint with the flag on and off, which is what proves the trimming happens before conversion.