### PR TITLE
fix(github): explain rate limiting instead of a bare 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ No escape
 GitHub token
 ------------
 
-Without a GitHub token, the `/markdown/raw` endpoint allows very few requests per hour; when the rate limit is exceeded, the tool will suggest passing a token.
+Without a GitHub token, the `/markdown/raw` endpoint allows very few requests per hour; when the rate limit is exceeded, the tool will suggest passing a token via `--token`, `GH_TOC_TOKEN`, or `token.txt`.
 All your tokents are [here](https://github.com/settings/tokens).
 
 Example for cli argument:

--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ No escape
 GitHub token
 ------------
 
+Without a GitHub token, the `/markdown/raw` endpoint allows very few requests per hour; when the rate limit is exceeded, the tool will suggest passing a token.
 All your tokents are [here](https://github.com/settings/tokens).
 
 Example for cli argument:

--- a/internal/adapters/htmlconverter.go
+++ b/internal/adapters/htmlconverter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 type remotePoster interface {
@@ -47,16 +48,27 @@ func (c *HTMLConverter) Convert(ctx context.Context, file string) (string, error
 	return html, nil
 }
 
+// rateLimitMarker is what GitHub puts in the body when the API rate limit is hit.
+// The bash gh-md-toc greps the response for the same string.
+const rateLimitMarker = "API rate limit exceeded"
+
 // withRateLimitHint points the user at the token options when GitHub throttles us.
-// Without a token the markdown endpoint allows very few requests per hour.
+// A 403 on its own is not enough: GitHub also returns it for bad credentials and for
+// a token missing a scope, and sending those users off to fetch a token would be
+// misleading. A 429 is unambiguous.
 func withRateLimitHint(err error) error {
 	var statusErr *HTTPStatusError
 	if !errors.As(err, &statusErr) {
 		return err
 	}
-	if statusErr.StatusCode != http.StatusForbidden &&
-		statusErr.StatusCode != http.StatusTooManyRequests {
+
+	rateLimited := statusErr.StatusCode == http.StatusTooManyRequests ||
+		(statusErr.StatusCode == http.StatusForbidden &&
+			strings.Contains(statusErr.Body, rateLimitMarker))
+	if !rateLimited {
 		return err
 	}
-	return fmt.Errorf("%w (GitHub API rate limit reached, pass --token or set GH_TOC_TOKEN)", err)
+	return fmt.Errorf(
+		"%w (GitHub API rate limit reached, pass --token, set GH_TOC_TOKEN, "+
+			"or put the token in token.txt next to the binary)", err)
 }

--- a/internal/adapters/htmlconverter.go
+++ b/internal/adapters/htmlconverter.go
@@ -2,6 +2,8 @@ package adapters
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 )
 
@@ -37,5 +39,24 @@ func (c *HTMLConverter) Convert(ctx context.Context, file string) (string, error
 	c.log.Info("adapters.HTMLConverter.Convert: start", "file", file)
 	ghURL := c.ghURL + "/markdown/raw"
 	c.log.Info("adapters.HTMLConverter.Convert: sending", "url", ghURL)
-	return c.poster.Post(ctx, ghURL, c.ghToken, file)
+
+	html, err := c.poster.Post(ctx, ghURL, c.ghToken, file)
+	if err != nil {
+		return "", withRateLimitHint(err)
+	}
+	return html, nil
+}
+
+// withRateLimitHint points the user at the token options when GitHub throttles us.
+// Without a token the markdown endpoint allows very few requests per hour.
+func withRateLimitHint(err error) error {
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		return err
+	}
+	if statusErr.StatusCode != http.StatusForbidden &&
+		statusErr.StatusCode != http.StatusTooManyRequests {
+		return err
+	}
+	return fmt.Errorf("%w (GitHub API rate limit reached, pass --token or set GH_TOC_TOKEN)", err)
 }

--- a/internal/adapters/htmlconverter_test.go
+++ b/internal/adapters/htmlconverter_test.go
@@ -3,6 +3,8 @@ package adapters
 import (
 	"context"
 	"errors"
+	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -72,5 +74,54 @@ func Test_HTMLConverterX(t *testing.T) {
 	_, ok := converter.poster.(*RemotePoster)
 	if !ok {
 		t.Errorf("converter is not of type RemotePoster")
+	}
+}
+
+type posterStub struct{ err error }
+
+func (s posterStub) Post(context.Context, string, string, string) (string, error) {
+	return "", s.err
+}
+
+func TestHTMLConverterRateLimitHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantHint bool
+	}{
+		{
+			name:     "forbidden",
+			err:      &HTTPStatusError{StatusCode: http.StatusForbidden, Body: "API rate limit exceeded"},
+			wantHint: true,
+		},
+		{
+			name:     "too many requests",
+			err:      &HTTPStatusError{StatusCode: http.StatusTooManyRequests},
+			wantHint: true,
+		},
+		{
+			name:     "server error keeps the bare message",
+			err:      &HTTPStatusError{StatusCode: http.StatusInternalServerError},
+			wantHint: false,
+		},
+		{
+			name:     "transport error keeps the bare message",
+			err:      errors.New("connection refused"),
+			wantHint: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := NewHTMLConverterX("", "https://api.github.com", posterStub{err: tt.err}, NewLogger(false))
+
+			_, err := converter.Convert(context.Background(), "README.md")
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("got error %v, want the original wrapped", err)
+			}
+			hasHint := strings.Contains(err.Error(), "GH_TOC_TOKEN")
+			if hasHint != tt.wantHint {
+				t.Errorf("got hint=%v in %q, want %v", hasHint, err, tt.wantHint)
+			}
+		})
 	}
 }

--- a/internal/adapters/htmlconverter_test.go
+++ b/internal/adapters/htmlconverter_test.go
@@ -100,6 +100,11 @@ func TestHTMLConverterRateLimitHint(t *testing.T) {
 			wantHint: true,
 		},
 		{
+			name:     "forbidden for a reason other than the rate limit",
+			err:      &HTTPStatusError{StatusCode: http.StatusForbidden, Body: `{"message":"Bad credentials"}`},
+			wantHint: false,
+		},
+		{
 			name:     "server error keeps the bare message",
 			err:      &HTTPStatusError{StatusCode: http.StatusInternalServerError},
 			wantHint: false,


### PR DESCRIPTION
Stacked on #79. Review that one first.

## What changed

A GitHub rate-limit response now carries a hint naming all three token sources instead of surfacing a bare `unexpected HTTP status 403`.

The trigger follows bash: 429 unconditionally, and 403 only when the response body contains `API rate limit exceeded`.

## Why

Without a token the `/markdown/raw` endpoint allows very few requests per hour, so this is the most common failure a new user hits.

Gating 403 on the body matters: GitHub also returns 403 for bad credentials and for a token missing a scope. Sending those users off to fetch a token would point them at the wrong problem. bash greps the body for the same string.

## Compatibility

Error text only; the original error stays reachable through `errors.Is`/`errors.As`.

## Validation

```
go test ./...
go vet ./...
```

The table covers 403 with the marker, 429 with an empty body, 403 with `Bad credentials`, a 500, and a transport error.