### PR TITLE
chore(ci): build with Go 1.26.6 to clear stdlib vulnerabilities

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Run converting
         run: make e2e

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         go-version:
           - "1.21.x"
-          - "1.26.5"
+          - "1.26.6"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Verify modules
         run: go mod verify
@@ -75,5 +75,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: "1.26.5"
+          go-version-input: "1.26.6"
           go-package: ./...

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Verify tag matches the app version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ CLI behaviour, not about the output format.
   dumped configuration. **If you ran `gh-md-toc --debug` in CI or any environment with
   shared logs, rotate that token.** The debug output now only reports whether a token was
   configured. ([#60](https://github.com/ekalinin/github-markdown-toc.go/pull/60))
+- CI and releases now build with Go 1.26.6. Go 1.26.5 carried four standard-library
+  vulnerabilities that `govulncheck` reports as reachable from this code:
+  [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) (`net/url`),
+  [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) (`crypto/tls`),
+  [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) (`encoding/asn1`) and
+  [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) (`net/http`). Binaries you built
+  yourself with Go 1.26.5 or earlier should be rebuilt.
 
 ### Changed
 
@@ -41,7 +48,7 @@ CLI behaviour, not about the output format.
 - Error messages name the document that failed and the operation that failed on it.
   ([#61](https://github.com/ekalinin/github-markdown-toc.go/pull/61))
 - Building from source now requires Go 1.21 or newer, matching the `log/slog` usage that
-  was already in the code. Releases are built with Go 1.26.5.
+  was already in the code. Releases are built with Go 1.26.6.
   ([#58](https://github.com/ekalinin/github-markdown-toc.go/pull/58))
 
 ### Fixed


### PR DESCRIPTION
Base of the parity stack: #76 is now stacked on this.

## What changed

Every workflow pin moves from Go 1.26.5 to 1.26.6 - the test matrix, the module-verification job, the `govulncheck` action input, the release build, and the e2e job.

## Why

`govulncheck` reports four standard-library vulnerabilities in 1.26.5 as reachable from this code:

| ID | Package | Reached via |
|---|---|---|
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` | `adapters.doHTTPReq` -> `http.Client.Do` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` | `adapters.doHTTPReq` -> `tls.Conn.HandshakeContext` |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` | certificate parsing on the same path |
| [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) | `net/http` | `adapters.doHTTPReq` |

All four are fixed in 1.26.6. This is pre-existing on `master`, not introduced by the parity work, but it fails the vulnerability job on every PR in the stack.

## Compatibility

CI and release toolchain only. `go.mod` still declares `go 1.21`, and building from source with 1.21 is unaffected.

## Validation

```
GOTOOLCHAIN=go1.26.6 govulncheck ./...
No vulnerabilities found.

go test ./...
go vet ./...
```